### PR TITLE
Extract generalizable cryptanalysis primitives from experiments/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,3 +325,5 @@ python examples/lp_analysis.py     # Run Liber Primus analysis
 8. **Test Coverage**: Maintain comprehensive tests. The project uses Hypothesis for property-based testing.
 
 9. **Module Imports**: Use package-level imports when possible: `from aldegonde.stats import ioc` instead of `from aldegonde.stats.ioc import ioc`.
+
+10. **Library First**: Before writing any statistical or cryptographic helper function — in an experiment script or anywhere else — check the question → API lookup table in `experiments/CLAUDE.md`. Re-implementing an existing primitive inline is a bug. If the primitive is missing, check `docs/extraction-candidates.md` for whether it is slated for extraction.

--- a/docs/extraction-candidates.md
+++ b/docs/extraction-candidates.md
@@ -451,6 +451,42 @@ Each appears only once or twice but fills a structural blind spot:
   `mixedalphabet` duplicates — migrate the experiments to the library
   API instead.
 
+## Discoverability plan
+
+Extraction only pays off if the next experiment script — usually written
+by an AI agent — reaches for the library instead of re-deriving the
+primitive. The ~15 inline `ioc` copies happened *while the library
+already had it*, so this needs explicit mechanisms:
+
+1. **Directory-scoped agent guide** (done): `experiments/CLAUDE.md`
+   carries a question → API lookup table for everything the library
+   provides today, the corpus-loading conventions, and the standing
+   rules (multiple-comparison discipline, correct-null discipline,
+   self-test-your-attack). Agents working in `experiments/` load it
+   automatically. **It must be updated in the same commit as every
+   extraction slice** — a primitive that isn't in the table doesn't
+   exist, as far as agents are concerned.
+2. **Root `CLAUDE.md` pointer**: the project guide directs anyone
+   writing analysis code to the lookup table before implementing
+   helpers.
+3. **Migrate experiments as each slice lands.** Agents pattern-match
+   from neighboring files far more than from documentation; a directory
+   where `lag11_depletion.py`-style library-importing scripts are the
+   norm teaches the right habit by example. Migration doubles as the
+   regression test for the extracted API.
+4. **Question-oriented naming and docstrings.** Name functions after the
+   question they answer (`boundary_coincidence`, `family_pvalue`), and
+   put the recurring question in the first docstring line so grep and
+   semantic search both land on it.
+5. **Keep package-level exports complete.** Everything importable as
+   `from aldegonde.stats import X` with `X` in `__all__`; sub-module
+   paths (`aldegonde.stats.ioc.ioc`) are where discoverability goes to
+   die.
+6. **Optional CI tripwire**: a lint step that greps `experiments/` for
+   definitions shadowing known library primitives (`def ioc`,
+   `def nioc`, `def sieve`, `def mixedalphabet`, `def hill_climb`, …)
+   and fails with a pointer to the lookup table.
+
 ## Suggested sequencing
 
 1. **Core stats slice** (items 1–4): generative doublet-rate null,

--- a/docs/extraction-candidates.md
+++ b/docs/extraction-candidates.md
@@ -122,12 +122,22 @@ A cluster of small, constantly re-derived pieces that belong together:
 - **Kappa z-spectrum over all lags with a frequency-matched null**
   (`lag11_depletion.py:85` — uses p = Σf², strictly better than the 1/N
   null used elsewhere; also `obs_kappa_spectrum.py:12`,
-  `gap_audit.py:78`, `jstream_battery.py:49`, `gf29_battery.py:57`),
-  with the √(2 ln n) expected-max threshold (4 verbatim copies:
+  `gap_audit.py:78`, `jstream_battery.py:49`, `gf29_battery.py:57`).
+- **Multiple-testing helpers** — every scan re-derives its own
+  correction, and they belong in one small module:
+  **Bonferroni** thresholds and budgets
+  (`recurrence_scan.py:43` — `chi2.isf(alpha/ntests, df)` over the
+  coefficient×lag grid; `lp_battery14.py:72` explicit test-count budget;
+  `gf29_battery.py:94` lagged-Fibonacci scan; `jstream_battery.py:117`),
+  **Šidák** correction (`lag11_depletion.py:202`), the
+  **√(2 ln n) expected-max threshold** for z-spectra (4 verbatim copies:
   `jstream_battery.py`, `gf29_battery.py`, `pattern_census.py:81`,
-  `residual_tests.py:97`), Šidák correction (`lag11_depletion.py:202`),
-  and the "observed vs expected count of |z| ≥ t" multiplicity budget
-  (`lag11_depletion.py:119`).
+  `residual_tests.py:97`), and the
+  "observed vs expected count of |z| ≥ t" **multiplicity budget**
+  (`lag11_depletion.py:119`). These are the analytic complements to the
+  empirical family-wise `stats/resample.family_pvalue` that already
+  exists: Bonferroni/Šidák when trials are cheap and the null is known,
+  the resampled max when it is not.
 - **Wilson-Hilferty chi²→z→p helper** — 4 verbatim copies
   (`obs_flat_ioc.py:17`, `obs_bigram_ioc.py:22`, `obs_dependence.py:12`,
   `obs_line_initial.py:18`).
@@ -152,8 +162,10 @@ A cluster of small, constantly re-derived pieces that belong together:
   (`recurrence_scan.py:43`, `gf29_battery.py:94`) — the canonical
   LFSR / lagged-Fibonacci / affine-relation detector for any modulus.
 
-**Home:** a new `stats/chisq.py` plus additions to `stats/kappa.py` and a
-new `analysis/relations.py` for the functional scans.
+**Home:** a new `stats/multitest.py` (Bonferroni, Šidák, expected-max,
+multiplicity budget), a new `stats/chisq.py`, additions to
+`stats/kappa.py`, and a new `analysis/relations.py` for the functional
+scans.
 
 ### 4. Permutation algebra + doublet-rate bounds
 

--- a/docs/extraction-candidates.md
+++ b/docs/extraction-candidates.md
@@ -39,7 +39,7 @@ default and the look-elsewhere correction unavoidable.
 
 ## Tier 1 — highest duplication pressure, clearly general
 
-### 1. Generative doublet-rate-matched Markov null
+### 1. Generative Markov surrogate null (constrained transitions)
 
 **Copies (~10):** `delta5_generalization.py:80` (`surrogates`, batched
 numpy), `aligned_kappa_nulls.py:90` (`gen_doublet_suppressed`),
@@ -48,16 +48,29 @@ numpy), `aligned_kappa_nulls.py:90` (`gen_doublet_suppressed`),
 (`gen_suppressed`), `phrase_repeats.py:82`, `word_transform_census.py:162`,
 `transposition_link.py:114`, `depth_search.py:91`.
 
-The single most-copied piece of code in `experiments/`. It is **not** the
-same as the existing `stats/nulls.doublet_shuffle`: that null is
-frequency-exact and shuffle-based, while every one of these files needs
-the *generative* first-order Markov form — uniform marginals with the
-diagonal transition probability pinned to an observed doublet rate — plus
-a batched `(n_surrogates, length)` vectorized variant for Monte Carlo
-loops.
+The single most-copied piece of code in `experiments/`. Every copy is the
+LP-motivated special case (pin the self-transition probability to a
+suppressed doublet rate), but the primitive to extract is the general
+surrogate-data method: **generate sequences from a first-order Markov
+model whose transition structure carries a known second-order nuisance
+property**, so that downstream statistics are not credited for structure
+the null already contains. Two constructors cover every use seen here:
 
-**Home:** `stats/nulls.py` (e.g. `doublet_markov(alphabetsize, rate)`),
-alongside a batched helper. Companion nulls worth adding at the same time:
+- `markov_null(transitions)` — surrogates from a full transition matrix,
+  typically fitted from the observed sequence (the order-1 surrogate
+  standard in time-series analysis);
+- a constrained variant that pins only the diagonal (self-transition)
+  rate and leaves the rest uniform — the doublet case, one line on top.
+
+Beyond 3301 this is the right null wherever a corpus has a known
+bigram-level anomaly: Playfair-prepared plaintext (doubles split by a
+filler), languages with different gemination rates, machine ciphers with
+anti-repetition mechanisms. It is **not** the same as the existing
+`stats/nulls.doublet_shuffle`, which is frequency-exact and
+shuffle-based; these files need the *generative* form, plus a batched
+`(n_surrogates, length)` vectorized variant for Monte Carlo loops.
+
+**Home:** `stats/nulls.py`. Companion nulls worth adding at the same time:
 the **within-segment shuffle** (`plaintext_lag5_pairing.py:93` — preserves
 word length and composition, destroys morphology) and the analytic
 pattern-class expectation under the Markov null (`pattern_census.py:62`,
@@ -156,7 +169,11 @@ substitutions for a given bigram matrix**, via Hungarian assignment
 cycle-type-constrained variant by annealing
 (`advance_doublet_floor.py:82`). This is a cipher-independent bound for
 refuting whole mechanism classes ("no monoalphabetic step can produce a
-doublet rate this low for this language"). The inverse operation — tune a
+doublet rate this low for this language"). Stated generally: given any
+pair-weight matrix, the extremal diagonal mass over all permutations —
+the same assignment bound answers "can a substitution step explain this
+self-map rate?" for any language and any adjacency statistic, not just
+LP's suppressed doublets. The inverse operation — tune a
 permutation so a diagonal rate *hits a target* — is at
 `final_orbit_walk.py:42` and `mechanism_discriminator.py:99`.
 `parity` also enables an O(1) necessary-condition pre-filter for state

--- a/docs/extraction-candidates.md
+++ b/docs/extraction-candidates.md
@@ -19,7 +19,12 @@ n-gram boundary coincidence, `match_separations`,
 `within_delta_histogram`, and `bucket_coincidence`,
 `analysis.relations` covers the linear/positional scans,
 `analysis.bounds` the assignment doublet floor, and `aldegonde.perm`
-the permutation algebra. Experiment-file migration is still pending.
+the permutation algebra. Slice 2 (item 5) is extracted: `aldegonde.search`
+holds the generic hill climber (`hill_climb`, `multi_start`, the
+`swap`/`conjugation` neighborhoods) and the `filter_cascade` funnel, and
+`analysis.autokey_repeat` holds the key-independent ciphertext-autokey
+repeat constraint (`forced_equal_positions`, `count_violations`).
+Experiment-file migration is still pending.
 
 ## Meta-findings
 

--- a/docs/extraction-candidates.md
+++ b/docs/extraction-candidates.md
@@ -24,7 +24,13 @@ holds the generic hill climber (`hill_climb`, `multi_start`, the
 `swap`/`conjugation` neighborhoods) and the `filter_cascade` funnel, and
 `analysis.autokey_repeat` holds the key-independent ciphertext-autokey
 repeat constraint (`forced_equal_positions`, `count_violations`).
-Experiment-file migration is still pending.
+Slice 3 (items 6–8) is extracted: `maths.sequences` holds the
+integer-sequence keystream catalogue, `analysis.keystream` the offset
+scan with a self-calibrating empirical null and the autokey depth-split
+detector, `analysis.fingerprint` the fingerprint battery and its
+comparison, and the new `aldegonde.sim` subpackage the Markov control-text
+generator and length-distribution word cutter. Experiment-file migration
+is still pending.
 
 ## Meta-findings
 

--- a/docs/extraction-candidates.md
+++ b/docs/extraction-candidates.md
@@ -10,6 +10,17 @@ outside the Liber Primus context.
 
 Survey date: 2026-08-02.
 
+**Status:** slice 1 (items 1–4 below) is extracted: `stats.nulls`
+gained `markov_model`/`fitted_markov`/`doublet_markov` (with
+`c3301.low_doublet_markov_null` as the LP-tuned wrapper),
+`stats.chisq` and `stats.multitest` are new, `stats.kappa_spectrum`
+covers the frequency-matched z-spectrum, `analysis.coincidence` gained
+n-gram boundary coincidence, `match_separations`,
+`within_delta_histogram`, and `bucket_coincidence`,
+`analysis.relations` covers the linear/positional scans,
+`analysis.bounds` the assignment doublet floor, and `aldegonde.perm`
+the permutation algebra. Experiment-file migration is still pending.
+
 ## Meta-findings
 
 **Discoverability is half the problem.** `ioc`/`nioc` is re-implemented

--- a/docs/extraction-candidates.md
+++ b/docs/extraction-candidates.md
@@ -70,7 +70,14 @@ anti-repetition mechanisms. It is **not** the same as the existing
 shuffle-based; these files need the *generative* form, plus a batched
 `(n_surrogates, length)` vectorized variant for Monte Carlo loops.
 
-**Home:** `stats/nulls.py`. Companion nulls worth adding at the same time:
+**Home:** the general infrastructure — `markov_null(transitions)` and the
+constrained-diagonal constructor — goes in `stats/nulls.py`. The
+low-doublet specialization (the null pre-tuned to LP's suppressed doublet
+rate) is 3301-specific and lives with the 3301 code
+(`c3301.py` / the `c3301*` analysis modules), built on the general
+constructor rather than beside it.
+
+Companion nulls worth adding at the same time in `stats/nulls.py`:
 the **within-segment shuffle** (`plaintext_lag5_pairing.py:93` — preserves
 word length and composition, destroys morphology) and the analytic
 pattern-class expectation under the Markov null (`pattern_census.py:62`,

--- a/docs/extraction-candidates.md
+++ b/docs/extraction-candidates.md
@@ -29,8 +29,14 @@ integer-sequence keystream catalogue, `analysis.keystream` the offset
 scan with a self-calibrating empirical null and the autokey depth-split
 detector, `analysis.fingerprint` the fingerprint battery and its
 comparison, and the new `aldegonde.sim` subpackage the Markov control-text
-generator and length-distribution word cutter. Experiment-file migration
-is still pending.
+generator and length-distribution word cutter. Slice 4 (items 9–10 and
+the small wins) is extracted: `analysis.spectral` holds the FFT
+cross-correlation alignment detector and the multiplier-DFT periodicity
+scan, `analysis.fourpoint` the four-point coincidence statistic, and
+`stats.binomial` the coincidence z, Wilson score interval, and
+two-proportion z. Experiment-file migration onto all four slices is still
+pending — the recommended next step, since each migration is both the
+regression test and the proof the API is usable.
 
 ## Meta-findings
 

--- a/docs/extraction-candidates.md
+++ b/docs/extraction-candidates.md
@@ -1,0 +1,432 @@
+# Extraction candidates: `experiments/` → `src/aldegonde`
+
+A survey of the ~120 scripts in `experiments/` looking for reusable,
+generalizable cryptanalysis primitives worth promoting into the library.
+Every candidate below is alphabet-agnostic (works for any symbol set, not
+just A–Z or the 29-rune Cicada alphabet) and is judged by two signals:
+how often it is re-implemented inline across experiment files
+(duplication pressure), and whether it answers a question that recurs
+outside the Liber Primus context.
+
+Survey date: 2026-08-02.
+
+## Meta-findings
+
+**Discoverability is half the problem.** `ioc`/`nioc` is re-implemented
+inline in ~15 files, a prime `sieve()` in 4 (`lp_battery9.py:10`,
+`lp_battery13.py:17`, `lp_battery14.py:18`, `lp_cryptodiagnostics.py:164`),
+and keyword-mixed-alphabet construction in 3 — all of which already exist
+in the library (`stats/ioc.py`, `maths/primes.py`, `masc.mixedalphabet`).
+Extraction alone will not fix this; the library API needs to be the path
+of least resistance from an experiment script.
+
+**Extraction demonstrably works.** The newest experiments
+(`lag11_depletion.py`, `lag5_word_boundary.py`) import
+`analysis.coincidence.{boundary_coincidence, boundary_permutation_test,
+joint_coincidence, match_indicator}`, `stats.nulls.doublet_shuffle`, and
+`stats.resample.{monte_carlo_map, family_pvalue}` from previous extraction
+rounds, and are markedly shorter and more legible than the older files
+that hand-roll the same machinery.
+
+**The "wrong null" lesson recurs and should be institutionalized.** Two
+files independently document that a uniform-random null fabricates 4–5σ
+artifacts that vanish under a doublet-rate-matched null:
+`missed_tests.py:229` (isomorph excess) and `word_transform_census.py:162`
+(transform-pair census). Any new scan API should make the correct null the
+default and the look-elsewhere correction unavoidable.
+
+---
+
+## Tier 1 — highest duplication pressure, clearly general
+
+### 1. Generative doublet-rate-matched Markov null
+
+**Copies (~10):** `delta5_generalization.py:80` (`surrogates`, batched
+numpy), `aligned_kappa_nulls.py:90` (`gen_doublet_suppressed`),
+`lag5_digraph_chase.py:93`, `lag5_freshlook.py:132`,
+`isomorph_corrected.py:53` (`markov_sample`), `missed_tests.py:233`
+(`gen_suppressed`), `phrase_repeats.py:82`, `word_transform_census.py:162`,
+`transposition_link.py:114`, `depth_search.py:91`.
+
+The single most-copied piece of code in `experiments/`. It is **not** the
+same as the existing `stats/nulls.doublet_shuffle`: that null is
+frequency-exact and shuffle-based, while every one of these files needs
+the *generative* first-order Markov form — uniform marginals with the
+diagonal transition probability pinned to an observed doublet rate — plus
+a batched `(n_surrogates, length)` vectorized variant for Monte Carlo
+loops.
+
+**Home:** `stats/nulls.py` (e.g. `doublet_markov(alphabetsize, rate)`),
+alongside a batched helper. Companion nulls worth adding at the same time:
+the **within-segment shuffle** (`plaintext_lag5_pairing.py:93` — preserves
+word length and composition, destroys morphology) and the analytic
+pattern-class expectation under the Markov null (`pattern_census.py:62`,
+falling-factorial labeling count).
+
+### 2. Segment-aware coincidence statistics + boundary permutation null
+
+**Copies (~10):** `within_word_d5.py:62`, `within_word_delta_mixture.py:76`,
+`within_word_match_anatomy.py:69`, `within_word_phase_profile.py:81`,
+`within_word_position_decomposition.py:71`, `d5_partial_leak.py:62`,
+`solved_section_control.py:63`, `rune_s_lag5.py:75`,
+`plaintext_control_corpus.py:116`, `word_lattice.py:34` (`bucket_kappa`).
+
+Every file re-derives the same loops over a `(stream, word_id)` pair:
+
+- within-segment lag-d match rate, and the within/cross-boundary split
+- per-segment-length breakdown with exact binomial or Wilson intervals
+- delta histogram at lag d (the full N-bin `Q` vector)
+- digraph-repeats-at-distance-d (the XY..XY statistic)
+- separation histogram of consecutive lag-d matches
+  (`plaintext_lag5_pairing.py:38`, `thirty_symbol_battery.py:38` — a
+  fourth-order statistic nothing in the library computes)
+- pooled within-bucket coincidence for an arbitrary bucketing function
+  (`word_lattice.py:34` — the general "do these positions share key?" test)
+
+**Companion nulls:** the boundary (word-length) permutation null — keep
+the symbol stream byte-identical, shuffle only the length sequence, re-cut
+— exists in three independent copies (`within_word_d5.py:96`,
+`within_word_delta_mixture.py:176`, `within_word_phase_profile.py:95`),
+with the best, section-local version at `lag5_word_boundary.py:161`
+(never moves matches across section seams). A closed-form analytic mean
+for the within-segment distance-d null is at `rune_s_lag5.py:62`.
+
+**Home:** extend `analysis/coincidence.py` around a `SegmentedSequence`
+(stream + boundary index) abstraction; the null goes in `stats/nulls.py`.
+Generalizes to any segmentation: words, lines, columns, messages.
+
+### 3. Scan statistics and multiple-comparison discipline
+
+A cluster of small, constantly re-derived pieces that belong together:
+
+- **Kappa z-spectrum over all lags with a frequency-matched null**
+  (`lag11_depletion.py:85` — uses p = Σf², strictly better than the 1/N
+  null used elsewhere; also `obs_kappa_spectrum.py:12`,
+  `gap_audit.py:78`, `jstream_battery.py:49`, `gf29_battery.py:57`),
+  with the √(2 ln n) expected-max threshold (4 verbatim copies:
+  `jstream_battery.py`, `gf29_battery.py`, `pattern_census.py:81`,
+  `residual_tests.py:97`), Šidák correction (`lag11_depletion.py:202`),
+  and the "observed vs expected count of |z| ≥ t" multiplicity budget
+  (`lag11_depletion.py:119`).
+- **Wilson-Hilferty chi²→z→p helper** — 4 verbatim copies
+  (`obs_flat_ioc.py:17`, `obs_bigram_ioc.py:22`, `obs_dependence.py:12`,
+  `obs_line_initial.py:18`).
+- **Off-diagonal-masked chi²** — 3 copies (`alignment_scan.py:174`,
+  `fourth_order_ciphers.py:79`, `obs_bigram_ioc.py:19`). Essential
+  whenever the diagonal is contaminated by doublet suppression.
+- **Exposure-weighted rate-uniformity chi²**
+  (`doublet_placement.py:23` `chi2_uniform_rate`; hand-rolled again in
+  `doublet_word_position.py:156` and `doublet_insertion_test.py:44`) —
+  "do events cluster on axis X?" with unequal exposure per bin. Distinct
+  from the existing `stats/position.py`, which tests frequencies, not
+  rates.
+- **Full N×N lag-contingency chi² scan** (`dependence_scan.py:30`,
+  `obs_dependence.py:12`, `missed_tests.py:80`) — the omnibus dependence
+  test that kappa (equality-only) cannot see, with the diagonal /
+  off-diagonal split as an option.
+- **Linear/affine functional uniformity scan** over
+  `(C[i+d] + a·C[i]) mod N` and `(C[i] + a·i) mod N`
+  (`dependence_scan.py:52`, `jstream_battery.py:117`,
+  `gf29_battery.py:76`), and the 3-term lagged-Fibonacci /
+  linear-recurrence scan with Bonferroni thresholds
+  (`recurrence_scan.py:43`, `gf29_battery.py:94`) — the canonical
+  LFSR / lagged-Fibonacci / affine-relation detector for any modulus.
+
+**Home:** a new `stats/chisq.py` plus additions to `stats/kappa.py` and a
+new `analysis/relations.py` for the functional scans.
+
+### 4. Permutation algebra + doublet-rate bounds
+
+**Copies (6 files, two dialects):** `walk_verifier.py:51`
+(`compose`/`ppow`/`order` and `parity` at `:145`), `stay_slot_cipher.py:87`
+(`perm_from_cycles`/`conj_swap`/`tune`), `two_gear_cipher.py:105`,
+`length_clocked_cipher.py:23`, `mealy_cipher.py:33`
+(derangements, Latin squares), `advance_doublet_floor.py:53`
+(`cycle_structure`/`cycles_to_perm`).
+
+The library (`masc.py`) has `cycles` and `mixedalphabet` but no
+composition, inversion, powers, order, parity, cycle-type construction,
+conjugate-swap mutation, derangements, or Latin squares — all needed for
+any rotor/gear/progressive-cipher work.
+
+The jewel on top: **the provable min/max doublet rate over all
+substitutions for a given bigram matrix**, via Hungarian assignment
+(`advance_doublet_floor.py:123` and `:130`; independently at
+`related_alphabet_cipher.py:112` and `two_gear_cipher.py:216`), plus the
+cycle-type-constrained variant by annealing
+(`advance_doublet_floor.py:82`). This is a cipher-independent bound for
+refuting whole mechanism classes ("no monoalphabetic step can produce a
+doublet rate this low for this language"). The inverse operation — tune a
+permutation so a diagonal rate *hits a target* — is at
+`final_orbit_walk.py:42` and `mechanism_discriminator.py:99`.
+`parity` also enables an O(1) necessary-condition pre-filter for state
+return (`walk_verifier.py:162`).
+
+**Home:** new `aldegonde/perm.py` (pure algebra) with the bigram-bound
+functions in `analysis/` (they need a bigram matrix, optionally scipy).
+
+### 5. Hill-climbing solver framework
+
+**Copies (3 near-identical + 1 variant):** `quagmire_hillclimber.py:119`,
+`quagmire_az_hillclimber.py:152`, `quagmire_repeat_attack.py:204` — all
+implement (injected score function, swap-two neighborhood, best-tracking,
+stagnation counter, random restarts) plus a `multiprocessing.Pool`
+job-grid driver. A fourth dialect (`tune`/`conj_swap` hill-climb over
+permutations under a fixed cycle type) lives in `stay_slot_cipher.py:106`
+and is imported by `mechanism_discriminator.py`, `final_orbit_walk.py`,
+and `phase_absorbing_walk.py`. The library has **no** solver module.
+
+Proven companions worth extracting with it:
+
+- **Repeat-consistency structural constraint for autokey ciphers**
+  (`quagmire_repeat_attack.py:42,55,129`): for ciphertext autokey,
+  identical ciphertext runs must decrypt to identical plaintext tails
+  from position 2 on, regardless of the preceding symbol — a
+  key-independent validity check, and occurrences with differing
+  predecessors yield alphabet constraint pairs. Composite scorer
+  "n-gram fitness − structural-violation penalty" at `:177`.
+- **Cheap→expensive filter cascade with round-trip self-test**
+  (`walk_verifier.py:129,162,176,187,284`): parity pre-filter →
+  state-return hard filter → diagonal score → n-gram hill-climb, with a
+  self-test that plants a known key, confirms the cascade accepts it and
+  rejects random keys. The self-test idiom should be a library
+  convention for any keyspace search.
+- **Allocation-free fast IoC scorer** for inner loops
+  (`quagmire_hillclimber.py:94` `score_ioc_fast`) — genuinely missing;
+  the current `stats/ioc.py` allocates per call.
+
+**Home:** new `aldegonde/search/` subpackage.
+
+---
+
+## Tier 2 — strong, 2–6 occurrences
+
+### 6. Fingerprint battery / mechanism kill-table
+
+**Copies (6+):** `mechanism_fingerprint.py:375`, `lp_battery11.py:34`,
+`stay_slot_cipher.py:188` (`battery`), `two_gear_cipher.py:174`,
+`product_form_ciphers.py:136`, `inner_layer_sim.py:152` (`j_stats`),
+`period5_quagmire_sim.py:122`, `mechanism_discriminator.py:66`
+(`profile`), `fourth_order_ciphers.py:65`.
+
+One call computing a named vector of discriminating statistics — nIoC,
+doublet/triplet rates, kappa spectrum, within-segment coincidence profile
+d=1..k, column IoCs, paired-match counts, delta chi² — plus a
+comparison-table printer. Turns "is my ciphertext consistent with
+mechanism X?" into: simulate X, fingerprint both, compare. The
+weighted-distance scoring + parameter grid search variant is at
+`five_block_simulator.py:113`.
+
+**Home:** `analysis/fingerprint.py`, built on the Tier-1 statistics.
+
+### 7. Keystream attack toolkit
+
+Spread over ~8 files:
+
+- **Integer-sequence keystream catalogue mod N** — primes, prime gaps,
+  totient, Möbius, divisor sums, Fibonacci/Lucas/tribonacci, figurate
+  numbers, π/e digits, 2^i (`lp_battery13.py:44` `STREAMS`,
+  `number_sequence_keys.py:61`, `lp_battery14.py:37`,
+  `lp_battery9.py:36`). Natural extension of `aldegonde/maths/`.
+- **Keystream-strip scan** over {sequence × offset × sign} scored by
+  IoC/log-likelihood with an empirical Monte-Carlo null and
+  multiple-comparison threshold (`totient_strip.py:57`,
+  `lp_battery14.py:53`). The **self-calibrating empirical null** — derive
+  z from the distribution of wrong-offset scores instead of modeling the
+  null analytically (`lp_battery14.py:62`) — is the reusable trick, and
+  applies to every brute-force scan in the repository. Positive-control
+  sanity check on a known-solved input at `lp_battery14.py:75`.
+- **Interrupter/drift-tolerant keystream decryption** — exact Viterbi DP
+  over a monotone non-decreasing key-index drift with skip penalty
+  (`lp_battery9.py:80`), beam-search fallback for non-monotone interrupts
+  (`lp_attack_battery.py:78`), and the event-driven key-index map
+  abstraction (`lp_battery13.py:56` `key_indices`).
+- **Key-index framing enumerator** — reset per word / per section / never
+  (`number_sequence_keys.py:143`) — orthogonal to the sequence choice,
+  applies to any running-key attack.
+- **Crib drag that tests the implied key fragment** for structure
+  (constant, arithmetic, low-entropy) instead of scoring plaintext,
+  with length-matched random-fragment nulls (`lp_battery15.py:61,85,98`).
+- **Autokey depth-split detector** — partition positions by the symbol at
+  lag L, pool per-group nIoC with numerator/denominator accumulation
+  (3 copies: `gap_audit.py:53` `split_depth` ≡ `lag5_digraph_chase.py:79`
+  `split_test`; `autokey_test.py:31`; generalized to arbitrary
+  conditioning tuples in `lp_cryptodiagnostics.py:588`). The **joint
+  multi-tap split test** (`product_form_ciphers.py:165`) — group C(n) by
+  a tuple of history taps and take the weighted mean group nIoC — is the
+  strongest form: one number falsifies the entire class of deterministic
+  `C(n) = f(P(n), history)` ciphers injective in P(n).
+- **Difference-stream depth search** with the analytic nIoC standard
+  deviation `sd = √(2(N−1)/(n(n−1)))` (scales as 1/n, easy to get wrong)
+  and the expected IoC of a difference of two texts
+  (`depth_search.py:31–64`).
+
+**Home:** new `analysis/keystream.py` + `maths/sequences.py`.
+
+### 8. Simulation kit: Markov corpus generator + cipher zoo
+
+- **Markov plaintext generator from n-gram tables** — 4+ copies
+  (`inner_layer_sim.py:36` order-2/3 with smoothing,
+  `mechanism_fingerprint.py:79`, `lp_battery11.py:18`,
+  `period5_quagmire_sim.py:44`, `stay_slot_cipher.py:45`). The library
+  ships `data/ngrams/*` but has no sampler.
+- **Word cutter from an empirical length distribution** — 4 copies
+  (`period5_quagmire_sim.py:75`, `stay_slot_cipher.py:71`, others).
+- **Greedy longest-match multigraph transliterator** (English → target
+  alphabet with digraph/trigraph rules) — appears in **8 files**
+  (`runeglish_frequency.py:71`, `plaintext_control_corpus.py:209`,
+  `quagmire_bigram_test.py:30`, `lp_attack_battery.py:116`,
+  `lp_battery15.py:28`, `product_form_ciphers.py:54`, …).
+- **Cipher zoo** — reference encryptors the library lacks entirely,
+  useful as null/comparison mechanisms: Chaocipher-N
+  (`lp_battery11.py:139`), Gromark chain-addition (`lp_battery11.py`),
+  Hill with internal rejection (`group_size_tests.py:145`), Mealy /
+  state-machine ciphers (`mealy_cipher.py:137`), bit-fractionation for
+  prime alphabets (`mechanism_fingerprint.py:188`), GF(N²) seriation
+  (`mechanism_fingerprint.py:216`), Lorenz-style wheel machine
+  (`mechanism_fingerprint.py:262`), progressive related-alphabet family
+  `A_φ = base ∘ g^φ` (`related_alphabet_cipher.py:133`,
+  `phase_absorbing_walk.py:40`), keyed-tableau (Quagmire III) autokey
+  (`custom_autokey_analysis.py:36`, `verify_quagmire_hypothesis.py:75`,
+  `quagmire_hillclimber.py:38` — mode {vigenère, beaufort, variant} ×
+  feedback {ciphertext, plaintext}), accumulator/running-sum autokey
+  (`accumulator_autokey_test.py:35`), homophonic-with-cycling and
+  keystream-rewind (`fourth_order_ciphers.py:97,136`), length-clocked
+  progressive substitution (`length_clocked_cipher.py:43`).
+
+**Home:** new `aldegonde/sim/` for generation; the cipher variants that
+are real ciphers (Chaocipher, Gromark, keyed-tableau autokey,
+accumulator autokey) belong in `auto.py`/`pasc.py`/new modules with
+round-trip tests.
+
+### 9. Higher-order and spectral detectors
+
+Each appears only once or twice but fills a structural blind spot:
+
+- **4-point statistic family P/V/X with closed-form expectations and a
+  global max-z look-elsewhere null** (`fourpoint_dragnet.py:64–104`,
+  null at `:117`; the P(L,1) scan reappears at
+  `fourth_order_ciphers.py:85`). Pure symbol-equality templates over any
+  alphabet; the statistic class relevant to Zodiac-340-style
+  transposition+homophonic ciphers, invisible to everything currently in
+  the library.
+- **FFT one-hot cross-correlation** — O(n log n) coincidence between two
+  streams at *every* alignment (`deep_scan.py:114`) — the general
+  keystream/pad-reuse detector; companion to `analysis/indepth.py`,
+  which only handles boundary-aligned units.
+- **Multiplier DFT scan** — for each multiplier m, FFT of
+  `exp(2πi·m·C/N)` with the Exp(1) per-bin null and max-order-statistic
+  threshold (`spectral_scan.py:38`) — detects additive periodic
+  structure at non-integer periods that Kasiski and integer-lag kappa
+  miss.
+- **Family-blind (lag × separation) pair-count grid** with an honest
+  "does *any* lag carry two cells ≥ observed" Monte Carlo
+  (`lag5_freshlook.py:116,130`); the chosen-family variant
+  `joint_t` is at `lag5_digraph_chase.py:57`.
+  `analysis/coincidence.joint_coincidence` covers only the chosen-family
+  case today.
+- **Discrete-log toolkit for prime-field alphabets**
+  (`gf29_battery.py:39–130`): dlog table from a primitive root,
+  power-residue character projections, character DFT — converts
+  multiplicative cipher hypotheses into additive ones the existing
+  tooling can already attack. Pairs with GF(p) `inv`/`safe_div`
+  (`gf29_mult_autokey.py:36`).
+
+### 10. Repeats and point-process upgrades
+
+- **Mismatch-tolerant seed-and-extend maximal repeats** with the
+  analytic null `pairs·C(L−1,k)·p^(L−k)·q^k`
+  (`sentence_forensics.py:183,226,243`); exact-maximal-repeat classes
+  with `expected_by_chance(n,k) = n²/(2·N^k)`
+  (`ciphertext_collisions.py:37,71`); bidirectional extension with
+  word-boundary-pattern agreement (`anchored_repeats.py:34`).
+  `stats/repeats.py` and `analysis/kasiski.py` only handle exact repeats
+  and distances.
+- **Repeat-distance factor spectrum with excess-over-1/f ranking**
+  (`lp_repeat_analysis.py:158`) — a quantitative Kasiski presentation.
+- **Point-process battery for event positions** (doublets, marks,
+  match clusters): CV, Fano factor over several bin widths,
+  KS-vs-exponential gaps, DFT peak ratio vs ln(n/2), GCD-of-gaps lattice
+  test, gaps mod N (`doublet_spacing.py:52–115`,
+  `mark_forensics.py:102–191`, `lp_cryptodiagnostics.py:474`).
+- **Context chi² around events** vs corpus (not uniform) frequency —
+  4 copies (`group_size_tests.py:50` `cat_test`,
+  `mark_thirty_symbol.py:46`, `lp_cryptodiagnostics.py:441`,
+  `lp_deep_analysis.py:70`).
+- **Insertion-vs-occupation test** for events in variable-length units
+  (length-weighted host-selection Monte Carlo,
+  `doublet_insertion_test.py:58`).
+
+---
+
+## Small clean wins (low effort, single-file but general)
+
+- Wilson score confidence interval, dependency-free
+  (`within_word_position_decomposition.py:59`), and the bucketed-rate
+  homogeneity reporter with FLAT/STRUCTURE verdict (`:81,93`).
+- Two-proportion z for "does the effect respect boundaries?"
+  (`obs_doublet_suppression.py:37`).
+- Conditional bigram entropy H(X₂|X₁) (`obs_entropy.py:19`) and the
+  compression-vs-shuffled-surrogate z across zlib/bz2/lzma
+  (`obs_entropy.py:36`, `lp_cryptodiagnostics.py:538`).
+- Mutual information at lags with the shuffle bias baseline
+  (`lp_cryptodiagnostics.py:557`) — finite-sample MI bias is non-zero,
+  the shuffle baseline is the correction.
+- Expressible-set / numerical-semigroup DP, 2 copies
+  (`boundary_tiling.py:52`, `cotiling_test.py:46`), plus the
+  inter-family grid-consistency test (`cotiling_test.py:56`).
+- Bigram antisymmetry chi² — count(a,b) vs count(b,a)
+  (`deep_scan.py:125`, `lp_cryptodiagnostics.py:487`).
+- Best shift×flip (atbash) distribution fit vs a reference, with an MC
+  null that accounts for minimizing over 2N transforms
+  (`covert_channels.py:64`).
+- Affine-normalized n-gram canonical signature — repeats invariant under
+  `y = m·x mod N` (`covert_channels.py:96`); modular sibling of
+  `stats/isomorph.py`.
+- Prev-occurrence-distance isomorph encoding, windowed
+  (`isomorph_corrected.py:26`) — and note `random_isomorph_statistics`
+  in `stats/isomorph.py` uses a uniform null, which `missed_tests.py`
+  shows is the wrong null for doublet-suppressed text.
+- Copy-vs-key-sharing delta-mixture discriminator: two one-parameter ML
+  models, an orthogonal projection statistic, pinned-parameter rejection,
+  and a bootstrap power calculation
+  (`within_word_delta_mixture.py:88–227`) — the template for "is this
+  coincidence excess a literal copy or a shared key?".
+- Positional-crib dictionary matcher — index a lexicon by
+  (length, fixed-symbol positions) (`ea_crib.py:72`).
+- Grid-built order-k permutation from a keyword (`enumerate_keys.py:67`),
+  mirror/palindrome+atbash symmetry z (`anomaly_scan.py:261`),
+  shortest-window-containing-all-symbols with MC null
+  (`deep_scan.py:204`), circular mean-resultant concentration of deltas
+  (`deep_scan.py:168`), block untransposition helper
+  (`transposition_link.py:85`).
+
+## Explicitly not worth extracting
+
+- LP corpus loaders and the `%`/`$` parsing idiom (~12 files): they
+  encode transcription conventions, not cryptanalysis. They should
+  collapse into **one** shared experiments-local module, not into
+  `src/aldegonde`.
+- `ocr_verify.py`: an excellent forced-alignment transcription-QA
+  pipeline, but out of scope for a cryptanalysis library.
+- Retracted or purely narrative files (`lag5_two_faces.py`,
+  `lp_bigram_compare.py`), and Gematria-Primus-specific hypothesis code.
+- Anything already in the library: inline `ioc`/`nioc`, sieves, totient,
+  `mixedalphabet` duplicates — migrate the experiments to the library
+  API instead.
+
+## Suggested sequencing
+
+1. **Core stats slice** (items 1–4): generative doublet-rate null,
+   segment-aware coincidence + boundary-permutation null, chi²/scan
+   discipline, permutation algebra + Hungarian doublet-floor bound.
+   Highest duplication counts, pure statistics/algebra, zero 3301
+   content, fits the existing `stats`/`analysis` architecture.
+2. **Solver framework** (item 5): a new subsystem deserving its own
+   design pass.
+3. **Keystream toolkit + simulation kit** (items 6–8).
+4. **Higher-order detectors and the small wins** (items 9–10), as needed
+   by live investigations.
+
+After each slice, migrate the experiment files that duplicate it — the
+migration is both the regression test and the proof the API is usable.

--- a/experiments/CLAUDE.md
+++ b/experiments/CLAUDE.md
@@ -52,6 +52,9 @@ All imports are package-level: `from aldegonde.stats import nioc`, etc.
 | Within-word delta histogram at lag d (the Q vector) | `analysis.within_delta_histogram` |
 | "Is the key a function of X?" pooled bucket coincidence | `analysis.bucket_coincidence` |
 | Second-order dependence beyond equality; beyond-doublet structure | `stats.lag_contingency` (`off_diagonal=True` masks the diagonal) |
+| Keystream/pad reuse between two streams (all shifts, O(n log n)) | `analysis.crosscorrelation_coincidence` |
+| Periodicity at non-integer periods (multiplier DFT) | `analysis.multiplier_dft` |
+| 4-point coincidence (structure pair/single tests can't see) | `analysis.fourpoint_coincidence` |
 | Affine/LFSR/drifting-key relation detection | `analysis.linear_relation_scan`, `analysis.positional_relation_scan` |
 | Min/max doublet rate any substitution can produce | `analysis.extremal_diagonal_rate` (+ `analysis.pair_counts`, `analysis.diagonal_rate`) |
 | Messages-in-depth / shared keystream detection | `analysis.alignment_coincidence` |
@@ -70,6 +73,7 @@ All imports are package-level: `from aldegonde.stats import nioc`, etc.
 | LP-tuned low-doublet nulls (3301 paths) | `c3301.low_doublet_null`, `c3301.low_doublet_markov_null` |
 | Chi-square with z and p: uniformity, weighted fit, rate-across-bins | `stats.uniformity`, `stats.goodness_of_fit`, `stats.rate_uniformity`, `stats.wilson_hilferty` |
 | Multiple-testing corrections: Bonferroni, Sidak, expected-max, budget | `stats.bonferroni`, `stats.sidak`, `stats.bonferroni_threshold`, `stats.sidak_threshold`, `stats.expected_max_z`, `stats.multiplicity_budget` |
+| Binomial coincidence z; Wilson interval; two-proportion (boundary) z | `stats.coincidence_z`, `stats.wilson_interval`, `stats.two_proportion_z` |
 | z-score | `stats.z_score` |
 
 Discipline: any statistic scanned over lags/periods/offsets needs a

--- a/experiments/CLAUDE.md
+++ b/experiments/CLAUDE.md
@@ -40,13 +40,20 @@ All imports are package-level: `from aldegonde.stats import nioc`, etc.
 | Need | Use |
 |---|---|
 | Kappa test at a skip; doublet/triplet counts | `stats.kappa`, `stats.doublets`, `stats.triplets` |
+| Kappa z-spectrum over lags, frequency-matched null | `stats.kappa_spectrum` |
 | Period detection (Friedman), with interrupter variant | `analysis.friedman_test`, `analysis.friedman_test_with_interrupter` |
 | Kasiski: repeat distances, factor spectrum | `analysis.kasiski_examination`, `analysis.repeat_distances`, `analysis.distance_spectrum` |
 | Repeated n-gram positions/distribution | `stats.repeat_positions`, `stats.repeat_distribution` |
 | Periodicity in irregular/mixed material | `analysis.krakup` |
 | Lag-L match indicator; joint (4th-order) coincidence | `analysis.match_indicator`, `analysis.joint_coincidence` |
-| Within-word vs cross-word coincidence at lag d | `analysis.boundary_coincidence` |
-| Word-boundary permutation test | `analysis.boundary_permutation_test` (+ `analysis.recut_words`, `analysis.word_index_map`) |
+| Within-word vs cross-word coincidence at lag d (n-grams too: XY..XY via `length=2`) | `analysis.boundary_coincidence` |
+| Word-boundary permutation test (section-local) | `analysis.boundary_permutation_test` (+ `analysis.recut_words`, `analysis.word_index_map`) |
+| Separation histogram between consecutive lag-d matches | `analysis.match_separations` |
+| Within-word delta histogram at lag d (the Q vector) | `analysis.within_delta_histogram` |
+| "Is the key a function of X?" pooled bucket coincidence | `analysis.bucket_coincidence` |
+| Second-order dependence beyond equality; beyond-doublet structure | `stats.lag_contingency` (`off_diagonal=True` masks the diagonal) |
+| Affine/LFSR/drifting-key relation detection | `analysis.linear_relation_scan`, `analysis.positional_relation_scan` |
+| Min/max doublet rate any substitution can produce | `analysis.extremal_diagonal_rate` (+ `analysis.pair_counts`, `analysis.diagonal_rate`) |
 | Messages-in-depth / shared keystream detection | `analysis.alignment_coincidence` |
 | Delta/difference streams (any modular op, any skip) | `analysis.delta`, `analysis.delta2`, `analysis.DeltaOp` |
 | Isomorph patterns and statistics | `stats.isomorph`, `stats.isomorph_statistics`, `stats.random_isomorph_statistics` |
@@ -58,7 +65,11 @@ All imports are package-level: `from aldegonde.stats import nioc`, etc.
 |---|---|
 | Monte Carlo: observed statistic vs null model | `stats.monte_carlo` (scalar), `stats.monte_carlo_map` (per-key) |
 | Family-wise p-value for the best peak in a scan | `stats.family_pvalue` |
-| Null models: shuffle, doublet-free, doublet-rate-matched | `stats.shuffle`, `stats.no_doublet_shuffle`, `stats.doublet_shuffle` |
+| Null models (multiset-exact): shuffle, doublet-free, doublet-rate-matched | `stats.shuffle`, `stats.no_doublet_shuffle`, `stats.doublet_shuffle` |
+| Null models (generative Markov): explicit chain, fitted chain, pinned doublet rate | `stats.markov_model`, `stats.fitted_markov`, `stats.doublet_markov` |
+| LP-tuned low-doublet nulls (3301 paths) | `c3301.low_doublet_null`, `c3301.low_doublet_markov_null` |
+| Chi-square with z and p: uniformity, weighted fit, rate-across-bins | `stats.uniformity`, `stats.goodness_of_fit`, `stats.rate_uniformity`, `stats.wilson_hilferty` |
+| Multiple-testing corrections: Bonferroni, Sidak, expected-max, budget | `stats.bonferroni`, `stats.sidak`, `stats.bonferroni_threshold`, `stats.sidak_threshold`, `stats.expected_max_z`, `stats.multiplicity_budget` |
 | z-score | `stats.z_score` |
 
 Discipline: any statistic scanned over lags/periods/offsets needs a
@@ -73,6 +84,7 @@ against a uniform null on doublet-suppressed text will produce artifacts
 |---|---|
 | Monoalphabetic encrypt/decrypt; Caesar/affine/atbash/random keys | `masc.masc_encrypt`, `masc.masc_decrypt`, `masc.shiftedkey`, `masc.affinekey`, `masc.atbashkey`, `masc.randomkey` |
 | Keyword-mixed alphabet; permutation cycles | `masc.mixedalphabet`, `masc.cycles` |
+| Permutation algebra: compose, invert, power, order, parity, cycle types, conjugation | `aldegonde.perm` (`from_key`/`to_key` bridge to masc keys) |
 | Polyalphabetic (Vigenère/Beaufort/Quagmire 1–4 tabula recta) | `pasc.pasc_encrypt`, `pasc.vigenere_tr`, `pasc.beaufort_tr`, `pasc.quagmire1_tr`…`quagmire4_tr` |
 | Autokey ciphers | `auto` |
 | Transposition / columnar | `trns`, `column` |

--- a/experiments/CLAUDE.md
+++ b/experiments/CLAUDE.md
@@ -87,6 +87,10 @@ against a uniform null on doublet-suppressed text will produce artifacts
 | Standard neighborhoods: swap two symbols; conjugate a permutation | `search.swap_neighbor`, `search.conjugation_neighbor` |
 | Cheap→expensive candidate filter with a survivor funnel | `search.filter_cascade` |
 | Ciphertext-autokey repeat constraints (key-independent) | `analysis.forced_equal_positions`, `analysis.count_violations` |
+| Running-key offset scan with a self-calibrating empirical null | `analysis.offset_scan` |
+| Ciphertext-autokey detector (pooled IoC by lagged symbol) | `analysis.autokey_split` |
+| Statistical fingerprint of a stream; compare to a reference | `analysis.fingerprint`, `analysis.compare` |
+| Markov control text: fit + generate; cut into words by length dist | `sim.fit_markov`, `sim.generate`, `sim.cut_by_lengths` |
 
 Discipline: before trusting a search that finds nothing, plant a known
 key/plaintext and confirm the search recovers it (or the cascade passes
@@ -105,6 +109,7 @@ brokenness. `search.hill_climb`/`multi_start` take an injected
 | Autokey ciphers | `auto` |
 | Transposition / columnar | `trns`, `column` |
 | Primes (sieve/generator), factorization | `maths.primes`, `maths.gen_primes_opt`, `maths.prime_factors`, `maths.factor_pairs` |
+| Keystream sequences mod N (first-n primes/totient/fib/figurate/…); one bundle | `maths.sequences` (`fibonacci`, `lucas`, `triangular`, `polygonal`, `prime_gaps`, `linear_recurrence`, …), `maths.catalogue` |
 | Totient, gcd, coprimality, Möbius | `maths.phi_func`, `maths.gcd`, `maths.is_coprime`, `maths.moebius` |
 | Modular inverse/division | `maths.modInverse`, `maths.modDivide` |
 | Cicada alphabet, rune↔index↔value conversions | `c3301.CICADA_ALPHABET`, `c3301.r2i`, `c3301.i2r`, `c3301.r2v`, `c3301.v2r` |

--- a/experiments/CLAUDE.md
+++ b/experiments/CLAUDE.md
@@ -78,6 +78,22 @@ Bonferroni budget explicitly. Any doublet-sensitive statistic tested
 against a uniform null on doublet-suppressed text will produce artifacts
 (see `missed_tests.py`, `word_transform_census.py`).
 
+### Key-space search
+
+| Need | Use |
+|---|---|
+| Hill climb a key (injected score + neighborhood) | `search.hill_climb` |
+| Multi-start hill climb (seeded, keeps best) | `search.multi_start` |
+| Standard neighborhoods: swap two symbols; conjugate a permutation | `search.swap_neighbor`, `search.conjugation_neighbor` |
+| Cheap→expensive candidate filter with a survivor funnel | `search.filter_cascade` |
+| Ciphertext-autokey repeat constraints (key-independent) | `analysis.forced_equal_positions`, `analysis.count_violations` |
+
+Discipline: before trusting a search that finds nothing, plant a known
+key/plaintext and confirm the search recovers it (or the cascade passes
+it). A search that cannot recover a planted key proves only its own
+brokenness. `search.hill_climb`/`multi_start` take an injected
+`random.Random`, so runs are reproducible.
+
 ### Ciphers, keys, math
 
 | Need | Use |

--- a/experiments/CLAUDE.md
+++ b/experiments/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md — experiments/ directory guide
+
+Instructions for AI assistants writing or modifying experiment scripts in
+this directory.
+
+## The prime directive: check the library first
+
+Before writing **any** helper function in an experiment script, check the
+lookup table below. A survey of this directory (see
+`docs/extraction-candidates.md`) found `ioc` re-implemented inline ~15
+times, prime sieves 4 times, and keyword-mixed alphabets 3 times — all of
+which the library already provided. Inline re-implementations are bugs:
+they drift, they skip validation, and they hide which experiments would
+benefit from a shared fix.
+
+If the primitive you need is not in the table, check
+`docs/extraction-candidates.md` — it may be slated for extraction, and
+you should flag the file you're writing as another duplication site.
+
+## Lookup table: question → library API
+
+All imports are package-level: `from aldegonde.stats import nioc`, etc.
+
+### Frequencies, IoC, entropy
+
+| Need | Use |
+|---|---|
+| Index of coincidence (raw / normalized) | `stats.ioc`, `stats.nioc` |
+| Bigram/trigram/tetragram IoC | `stats.ioc2`, `stats.ioc3`, `stats.ioc4` |
+| Sliding-window IoC | `stats.sliding_window_ioc` |
+| Mutual IoC between two texts | `stats.mioc`, `stats.nmioc` |
+| Rényi entropy family | `stats.renyi` |
+| Shannon entropy | `stats.shannon_entropy`, `stats.shannon2_entropy` |
+| N-gram counts/positions/distributions | `stats.ngrams`, `stats.ngram_distribution`, `stats.ngram_positions` |
+| Chi-square / G-test vs a reference distribution | `stats.mychisquare`, `stats.chisquarescipy`, `stats.gtest` |
+| N-gram log-probability fitness scoring | `stats.NgramScorer` (tables ship in `aldegonde/data/ngrams/`) |
+
+### Coincidence, periodicity, repeats
+
+| Need | Use |
+|---|---|
+| Kappa test at a skip; doublet/triplet counts | `stats.kappa`, `stats.doublets`, `stats.triplets` |
+| Period detection (Friedman), with interrupter variant | `analysis.friedman_test`, `analysis.friedman_test_with_interrupter` |
+| Kasiski: repeat distances, factor spectrum | `analysis.kasiski_examination`, `analysis.repeat_distances`, `analysis.distance_spectrum` |
+| Repeated n-gram positions/distribution | `stats.repeat_positions`, `stats.repeat_distribution` |
+| Periodicity in irregular/mixed material | `analysis.krakup` |
+| Lag-L match indicator; joint (4th-order) coincidence | `analysis.match_indicator`, `analysis.joint_coincidence` |
+| Within-word vs cross-word coincidence at lag d | `analysis.boundary_coincidence` |
+| Word-boundary permutation test | `analysis.boundary_permutation_test` (+ `analysis.recut_words`, `analysis.word_index_map`) |
+| Messages-in-depth / shared keystream detection | `analysis.alignment_coincidence` |
+| Delta/difference streams (any modular op, any skip) | `analysis.delta`, `analysis.delta2`, `analysis.DeltaOp` |
+| Isomorph patterns and statistics | `stats.isomorph`, `stats.isomorph_statistics`, `stats.random_isomorph_statistics` |
+| Position-in-token frequency bias | `stats.position_frequency_chi2` |
+
+### Significance testing
+
+| Need | Use |
+|---|---|
+| Monte Carlo: observed statistic vs null model | `stats.monte_carlo` (scalar), `stats.monte_carlo_map` (per-key) |
+| Family-wise p-value for the best peak in a scan | `stats.family_pvalue` |
+| Null models: shuffle, doublet-free, doublet-rate-matched | `stats.shuffle`, `stats.no_doublet_shuffle`, `stats.doublet_shuffle` |
+| z-score | `stats.z_score` |
+
+Discipline: any statistic scanned over lags/periods/offsets needs a
+multiple-comparison correction — use `stats.family_pvalue`, or state the
+Bonferroni budget explicitly. Any doublet-sensitive statistic tested
+against a uniform null on doublet-suppressed text will produce artifacts
+(see `missed_tests.py`, `word_transform_census.py`).
+
+### Ciphers, keys, math
+
+| Need | Use |
+|---|---|
+| Monoalphabetic encrypt/decrypt; Caesar/affine/atbash/random keys | `masc.masc_encrypt`, `masc.masc_decrypt`, `masc.shiftedkey`, `masc.affinekey`, `masc.atbashkey`, `masc.randomkey` |
+| Keyword-mixed alphabet; permutation cycles | `masc.mixedalphabet`, `masc.cycles` |
+| Polyalphabetic (Vigenère/Beaufort/Quagmire 1–4 tabula recta) | `pasc.pasc_encrypt`, `pasc.vigenere_tr`, `pasc.beaufort_tr`, `pasc.quagmire1_tr`…`quagmire4_tr` |
+| Autokey ciphers | `auto` |
+| Transposition / columnar | `trns`, `column` |
+| Primes (sieve/generator), factorization | `maths.primes`, `maths.gen_primes_opt`, `maths.prime_factors`, `maths.factor_pairs` |
+| Totient, gcd, coprimality, Möbius | `maths.phi_func`, `maths.gcd`, `maths.is_coprime`, `maths.moebius` |
+| Modular inverse/division | `maths.modInverse`, `maths.modDivide` |
+| Cicada alphabet, rune↔index↔value conversions | `c3301.CICADA_ALPHABET`, `c3301.r2i`, `c3301.i2r`, `c3301.r2v`, `c3301.v2r` |
+| Bigram diagram visualization | `grams.bigram_diagram` |
+
+## Conventions for this directory
+
+- **Corpus loading:** use the shared local loaders (`lp_corpus.py`,
+  `lp_structure.py`) rather than re-parsing the `%`/`$` conventions
+  inline. LP parsing stays in `experiments/`; it does not belong in
+  `src/aldegonde`.
+- **No absolute paths.** Some older scripts hardcode `/Users/...` paths;
+  do not copy that pattern — resolve paths relative to the repo root.
+- **Self-test your attacks.** Before trusting a negative result, plant a
+  known key/plaintext through your own pipeline and confirm the attack
+  recovers it (see `walk_verifier.py`, `lp_battery14.py` for the
+  pattern).
+- **When the library gains a primitive you had inlined,** migrate the
+  experiment to the library call — the migration is the regression test.

--- a/src/aldegonde/analysis/__init__.py
+++ b/src/aldegonde/analysis/__init__.py
@@ -6,6 +6,10 @@ from aldegonde.analysis.bounds import (
     extremal_diagonal_rate,
     pair_counts,
 )
+from aldegonde.analysis.autokey_repeat import (
+    count_violations,
+    forced_equal_positions,
+)
 from aldegonde.analysis.coincidence import (
     BoundaryCoincidence,
     BoundaryPermutation,
@@ -54,6 +58,9 @@ from aldegonde.analysis.split import (
 from aldegonde.analysis.twist import twist, twist_test, twist_test_with_interrupter
 
 __all__ = [
+    # autokey_repeat
+    "count_violations",
+    "forced_equal_positions",
     # bounds
     "DiagonalBound",
     "diagonal_rate",

--- a/src/aldegonde/analysis/__init__.py
+++ b/src/aldegonde/analysis/__init__.py
@@ -1,14 +1,24 @@
 """Cryptanalysis algorithms."""
 
+from aldegonde.analysis.bounds import (
+    DiagonalBound,
+    diagonal_rate,
+    extremal_diagonal_rate,
+    pair_counts,
+)
 from aldegonde.analysis.coincidence import (
     BoundaryCoincidence,
     BoundaryPermutation,
+    BucketCoincidence,
     JointCount,
     boundary_coincidence,
     boundary_permutation_test,
+    bucket_coincidence,
     joint_coincidence,
     match_indicator,
+    match_separations,
     recut_words,
+    within_delta_histogram,
     word_index_map,
 )
 from aldegonde.analysis.delta import DeltaOp, delta, delta2
@@ -20,6 +30,10 @@ from aldegonde.analysis.kasiski import (
     kasiski_examination,
     print_kasiski_statistics,
     repeat_distances,
+)
+from aldegonde.analysis.relations import (
+    linear_relation_scan,
+    positional_relation_scan,
 )
 from aldegonde.analysis.rune_frequency import (
     FrequencyProfile,
@@ -40,15 +54,24 @@ from aldegonde.analysis.split import (
 from aldegonde.analysis.twist import twist, twist_test, twist_test_with_interrupter
 
 __all__ = [
+    # bounds
+    "DiagonalBound",
+    "diagonal_rate",
+    "extremal_diagonal_rate",
+    "pair_counts",
     # coincidence
     "BoundaryCoincidence",
     "BoundaryPermutation",
+    "BucketCoincidence",
     "JointCount",
     "boundary_coincidence",
     "boundary_permutation_test",
+    "bucket_coincidence",
     "joint_coincidence",
     "match_indicator",
+    "match_separations",
     "recut_words",
+    "within_delta_histogram",
     "word_index_map",
     # delta
     "DeltaOp",
@@ -67,6 +90,9 @@ __all__ = [
     "kasiski_examination",
     "print_kasiski_statistics",
     "repeat_distances",
+    # relations
+    "linear_relation_scan",
+    "positional_relation_scan",
     # rune_frequency
     "FrequencyProfile",
     "find_best_suppression",

--- a/src/aldegonde/analysis/__init__.py
+++ b/src/aldegonde/analysis/__init__.py
@@ -26,6 +26,13 @@ from aldegonde.analysis.coincidence import (
     word_index_map,
 )
 from aldegonde.analysis.delta import DeltaOp, delta, delta2
+from aldegonde.analysis.fingerprint import compare, fingerprint
+from aldegonde.analysis.keystream import (
+    AutokeySplit,
+    OffsetHit,
+    autokey_split,
+    offset_scan,
+)
 from aldegonde.analysis.friedman import friedman_test, friedman_test_with_interrupter
 from aldegonde.analysis.guballa import bigram_break_pasc
 from aldegonde.analysis.indepth import AlignmentResult, alignment_coincidence
@@ -84,6 +91,14 @@ __all__ = [
     "DeltaOp",
     "delta",
     "delta2",
+    # fingerprint
+    "compare",
+    "fingerprint",
+    # keystream
+    "AutokeySplit",
+    "OffsetHit",
+    "autokey_split",
+    "offset_scan",
     # friedman
     "friedman_test",
     "friedman_test_with_interrupter",

--- a/src/aldegonde/analysis/__init__.py
+++ b/src/aldegonde/analysis/__init__.py
@@ -1,14 +1,14 @@
 """Cryptanalysis algorithms."""
 
+from aldegonde.analysis.autokey_repeat import (
+    count_violations,
+    forced_equal_positions,
+)
 from aldegonde.analysis.bounds import (
     DiagonalBound,
     diagonal_rate,
     extremal_diagonal_rate,
     pair_counts,
-)
-from aldegonde.analysis.autokey_repeat import (
-    count_violations,
-    forced_equal_positions,
 )
 from aldegonde.analysis.coincidence import (
     BoundaryCoincidence,
@@ -27,12 +27,7 @@ from aldegonde.analysis.coincidence import (
 )
 from aldegonde.analysis.delta import DeltaOp, delta, delta2
 from aldegonde.analysis.fingerprint import compare, fingerprint
-from aldegonde.analysis.keystream import (
-    AutokeySplit,
-    OffsetHit,
-    autokey_split,
-    offset_scan,
-)
+from aldegonde.analysis.fourpoint import FourPointCount, fourpoint_coincidence
 from aldegonde.analysis.friedman import friedman_test, friedman_test_with_interrupter
 from aldegonde.analysis.guballa import bigram_break_pasc
 from aldegonde.analysis.indepth import AlignmentResult, alignment_coincidence
@@ -41,6 +36,12 @@ from aldegonde.analysis.kasiski import (
     kasiski_examination,
     print_kasiski_statistics,
     repeat_distances,
+)
+from aldegonde.analysis.keystream import (
+    AutokeySplit,
+    OffsetHit,
+    autokey_split,
+    offset_scan,
 )
 from aldegonde.analysis.relations import (
     linear_relation_scan,
@@ -53,6 +54,12 @@ from aldegonde.analysis.rune_frequency import (
     natural_mapping,
     scan_state_spaces,
     truncated_byte_mapping,
+)
+from aldegonde.analysis.spectral import (
+    AlignmentPeak,
+    SpectralPeak,
+    crosscorrelation_coincidence,
+    multiplier_dft,
 )
 from aldegonde.analysis.split import (
     split_by_character,
@@ -94,6 +101,9 @@ __all__ = [
     # fingerprint
     "compare",
     "fingerprint",
+    # fourpoint
+    "FourPointCount",
+    "fourpoint_coincidence",
     # keystream
     "AutokeySplit",
     "OffsetHit",
@@ -115,6 +125,11 @@ __all__ = [
     # relations
     "linear_relation_scan",
     "positional_relation_scan",
+    # spectral
+    "AlignmentPeak",
+    "SpectralPeak",
+    "crosscorrelation_coincidence",
+    "multiplier_dft",
     # rune_frequency
     "FrequencyProfile",
     "find_best_suppression",

--- a/src/aldegonde/analysis/autokey_repeat.py
+++ b/src/aldegonde/analysis/autokey_repeat.py
@@ -1,0 +1,150 @@
+# ABOUTME: Key-independent structural constraints from repeated ciphertext
+# ABOUTME: under a ciphertext-autokey cipher: forced-equal plaintext positions.
+"""Repeat-consistency constraints for ciphertext autokey.
+
+A ciphertext-autokey cipher keys each position on an earlier ciphertext
+symbol: the plaintext at position i is a fixed unknown function of the
+ciphertext at i and at i - depth. That forces a structural fact that holds
+whatever the key is. Inside a repeated ciphertext substring, once the
+running position is at least `depth` past the start, both the ciphertext
+symbol and its key symbol are copies of symbols from earlier in the same
+matched run, so the two occurrences must decrypt to the same plaintext
+there.
+
+This module turns that observation into equivalence classes over stream
+positions — positions forced to share a plaintext symbol. The classes are
+key-independent, so they both prune a search (reject any candidate key
+whose plaintext is not constant within a class) and, where two occurrences
+have differing key symbols, pin relations the true tableau must satisfy.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+from aldegonde.exceptions import InvalidInputError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+T = TypeVar("T")
+
+
+class _Union:
+    """Minimal union-find over integer position labels."""
+
+    def __init__(self, n: int) -> None:
+        self.parent = list(range(n))
+
+    def find(self, x: int) -> int:
+        root = x
+        while self.parent[root] != root:
+            root = self.parent[root]
+        while self.parent[x] != root:
+            self.parent[x], x = root, self.parent[x]
+        return root
+
+    def union(self, a: int, b: int) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            self.parent[max(ra, rb)] = min(ra, rb)
+
+
+def forced_equal_positions(
+    cipher: Sequence[T],
+    depth: int,
+    window: int,
+) -> list[list[int]]:
+    """Group stream positions a ciphertext autokey forces to share plaintext.
+
+    Slides a window of length `window` over the ciphertext, groups equal
+    windows, and for every pair of equal windows links the positions at
+    offsets depth..window-1 — the tail beyond the point where both the
+    ciphertext and its autokey source are copies from inside the matched
+    window. The result is the set of equivalence classes of size two or
+    more.
+
+    Args:
+        cipher: Ciphertext stream
+        depth: Autokey feedback depth (key at i is the ciphertext at
+            i - depth)
+        window: Length of the repeated substrings to search; must exceed
+            depth to force anything
+
+    Returns:
+        Equivalence classes of stream positions, each a sorted list of at
+        least two positions forced to hold the same plaintext symbol
+
+    Raises:
+        InvalidInputError: If depth is negative, window is not positive, or
+            window does not exceed depth
+    """
+    if depth < 0:
+        msg = f"depth must be non-negative, got {depth}"
+        raise InvalidInputError(msg)
+    if window < 1:
+        msg = f"window must be positive, got {window}"
+        raise InvalidInputError(msg)
+    if window <= depth:
+        msg = f"window {window} must exceed depth {depth} to force positions"
+        raise InvalidInputError(msg)
+    n = len(cipher)
+    union = _Union(n)
+    groups: dict[tuple[T, ...], list[int]] = {}
+    for start in range(n - window + 1):
+        key = tuple(cipher[start : start + window])
+        groups.setdefault(key, []).append(start)
+    for starts in groups.values():
+        if len(starts) < 2:
+            continue
+        first = starts[0]
+        for other in starts[1:]:
+            for offset in range(depth, window):
+                union.union(first + offset, other + offset)
+    classes: dict[int, list[int]] = {}
+    for position in range(n):
+        root = union.find(position)
+        classes.setdefault(root, []).append(position)
+    return sorted(
+        (sorted(members) for members in classes.values() if len(members) > 1),
+        key=lambda members: members[0],
+    )
+
+
+def count_violations(
+    plaintext: Sequence[T],
+    classes: Sequence[Sequence[int]],
+) -> int:
+    """Count equivalence classes a candidate plaintext fails to keep constant.
+
+    A valid ciphertext-autokey decryption holds one plaintext symbol per
+    forced class; this counts the classes that contain more than one
+    distinct symbol. Zero means the plaintext respects every repeat
+    constraint — a necessary condition for the key, cheap to check inside a
+    search or a filter cascade.
+
+    Args:
+        plaintext: Candidate plaintext aligned to the ciphertext positions
+        classes: Equivalence classes from `forced_equal_positions`
+
+    Returns:
+        The number of classes holding more than one distinct plaintext
+        symbol
+
+    Raises:
+        InvalidInputError: If a class references a position outside the
+            plaintext
+    """
+    violations = 0
+    for members in classes:
+        symbols = set()
+        for position in members:
+            if not 0 <= position < len(plaintext):
+                msg = (
+                    f"position {position} outside plaintext of length {len(plaintext)}"
+                )
+                raise InvalidInputError(msg)
+            symbols.add(plaintext[position])
+        if len(symbols) > 1:
+            violations += 1
+    return violations

--- a/src/aldegonde/analysis/bounds.py
+++ b/src/aldegonde/analysis/bounds.py
@@ -1,0 +1,148 @@
+# ABOUTME: Extremal bounds on substitution-induced statistics: the min/max
+# ABOUTME: diagonal (doublet) rate any permutation can produce for a language.
+"""Extremal diagonal-rate bounds for monoalphabetic substitution steps.
+
+Given a matrix of adjacent-pair weights (a bigram count matrix of the
+plaintext language), a substitution step g exposes a doublet exactly where a
+pair (x, y) has y == g(x): the doublet rate it induces is the fraction of
+pair mass lying on the graph of g. Optimizing that mass over all
+permutations is an assignment problem, so the Hungarian algorithm yields the
+provable minimum and maximum doublet rate any monoalphabetic step can
+produce for the given language.
+
+These are cipher-independent bounds for refuting mechanism classes: if an
+observed doublet rate falls below the minimum, no substitution step over
+that language explains it, whatever the key. The same bound applies to any
+pair-weight matrix and lag, not only adjacent bigrams.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple, TypeVar
+
+import numpy as np
+from scipy.optimize import linear_sum_assignment
+
+from aldegonde.exceptions import InsufficientDataError, InvalidInputError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+T = TypeVar("T")
+
+
+def pair_counts(
+    text: Sequence[T],
+    alphabet: Sequence[T],
+    lag: int = 1,
+) -> list[list[int]]:
+    """Count ordered symbol pairs at a lag into an alphabet-indexed matrix.
+
+    Args:
+        text: Sequence to analyze
+        alphabet: The alphabet fixing the index of every symbol
+        lag: Distance between the paired symbols
+
+    Returns:
+        A matrix with entry [i][j] counting positions where alphabet[i] is
+        followed at distance lag by alphabet[j]
+
+    Raises:
+        InvalidInputError: If lag is not positive or a symbol is missing
+            from the alphabet
+    """
+    if lag < 1:
+        msg = f"lag must be positive, got {lag}"
+        raise InvalidInputError(msg)
+    index = {symbol: i for i, symbol in enumerate(alphabet)}
+    matrix = [[0] * len(alphabet) for _ in alphabet]
+    for i in range(len(text) - lag):
+        try:
+            matrix[index[text[i]]][index[text[i + lag]]] += 1
+        except KeyError as exc:
+            msg = f"symbol {exc.args[0]!r} not in alphabet"
+            raise InvalidInputError(msg) from exc
+    return matrix
+
+
+def diagonal_rate(
+    matrix: Sequence[Sequence[float]],
+    perm: Sequence[int],
+) -> float:
+    """Return the fraction of pair mass a permutation puts on its graph.
+
+    This is the doublet rate a substitution step with permutation `perm`
+    exposes when the pair weights describe the plaintext: the mass at
+    (x, perm[x]) summed over x, over the total mass.
+
+    Args:
+        matrix: Pair-weight matrix, e.g. from `pair_counts`
+        perm: Permutation in index form (see `aldegonde.perm`)
+
+    Returns:
+        The diagonal mass fraction, 0.0 when the matrix is empty
+
+    Raises:
+        InvalidInputError: If the permutation size differs from the matrix
+    """
+    if len(perm) != len(matrix):
+        msg = f"permutation size {len(perm)} != matrix size {len(matrix)}"
+        raise InvalidInputError(msg)
+    total = sum(sum(row) for row in matrix)
+    if total == 0:
+        return 0.0
+    return sum(matrix[x][perm[x]] for x in range(len(perm))) / total
+
+
+class DiagonalBound(NamedTuple):
+    """An extremal diagonal rate and a permutation attaining it.
+
+    Attributes:
+        rate: The extremal diagonal mass fraction
+        perm: A permutation in index form attaining it
+    """
+
+    rate: float
+    perm: list[int]
+
+
+def extremal_diagonal_rate(
+    matrix: Sequence[Sequence[float]],
+    *,
+    maximize: bool = False,
+) -> DiagonalBound:
+    """Return the minimum (or maximum) diagonal rate over all permutations.
+
+    Solves the assignment problem on the pair-weight matrix, so the bound is
+    exact and holds over the full symmetric group — not merely over the keys
+    some search visited. An observed doublet rate below the minimum refutes
+    every monoalphabetic substitution step over this language at once; a
+    cycle-type-restricted key class can only do worse than this bound, never
+    better.
+
+    Args:
+        matrix: Pair-weight matrix, e.g. from `pair_counts`
+        maximize: Return the maximum achievable rate instead of the minimum
+
+    Returns:
+        The extremal rate and a permutation attaining it
+
+    Raises:
+        InsufficientDataError: If the matrix is empty or holds no mass
+    """
+    if len(matrix) == 0:
+        msg = "extremal_diagonal_rate needs a non-empty matrix"
+        raise InsufficientDataError(msg, 1, 0)
+    weights = np.asarray(matrix, dtype=float)
+    total = float(weights.sum())
+    if total == 0:
+        msg = "extremal_diagonal_rate needs positive total pair mass"
+        raise InsufficientDataError(msg, 1, 0)
+    rows, columns = linear_sum_assignment(weights, maximize=maximize)
+    perm = [0] * len(matrix)
+    for row, column in zip(rows.tolist(), columns.tolist()):
+        perm[row] = column
+    return DiagonalBound(
+        rate=float(weights[rows, columns].sum()) / total,
+        perm=perm,
+    )

--- a/src/aldegonde/analysis/coincidence.py
+++ b/src/aldegonde/analysis/coincidence.py
@@ -16,6 +16,7 @@ All functions work on arbitrary alphabets (runes, integers, letters).
 
 import random
 import statistics
+from collections import Counter
 from collections.abc import Sequence
 from typing import NamedTuple, TypeVar
 
@@ -186,31 +187,39 @@ def recut_words(stream: Sequence[T], lengths: Sequence[int]) -> list[list[T]]:
 def boundary_coincidence(
     words: Sequence[Sequence[T]],
     lag: int,
+    length: int = 1,
 ) -> BoundaryCoincidence:
-    """Split the lag-L coincidence count by word membership.
+    """Split the lag-L n-gram coincidence count by word membership.
 
-    Counts matches on the concatenation of the words, classifying every
-    position pair (i, i + lag) as within-word when both positions fall in
-    the same word and as across-word otherwise. A within rate above the
-    across rate means the coincidences know where the word boundaries are.
+    Counts matches on the concatenation of the words, comparing the n-gram
+    starting at i with the n-gram starting at i + lag. A pair is within-word
+    when both n-grams fall entirely inside the same single word, and
+    across-word otherwise. A within rate above the across rate means the
+    coincidences know where the word boundaries are. Length 2 counts the
+    XY..XY digraph repeats at distance lag.
 
     Args:
         words: Tokenized text, one sequence per word
-        lag: Distance between the compared symbols
+        lag: Distance between the compared n-grams
+        length: Size of the compared n-grams (1 = single symbols)
 
     Returns:
         Observed matches and available pairs for both classes
 
     Raises:
-        InvalidInputError: If lag is not a positive integer
+        InvalidInputError: If lag or length is not a positive integer
         InsufficientDataError: If the concatenation is no longer than lag
     """
+    validate_positive_integer(lag, "lag")
+    validate_positive_integer(length, "length")
     stream = [symbol for word in words for symbol in word]
+    validate_text_sequence(stream, min_length=lag + 1)
     indices = word_index_map(words)
-    indicator = match_indicator(stream, lag)
     within_observed = within_pairs = across_observed = across_pairs = 0
-    for i, matched in enumerate(indicator):
-        if indices[i] == indices[i + lag]:
+    for i in range(len(stream) - lag - length + 1):
+        matched = stream[i : i + length] == stream[i + lag : i + lag + length]
+        # indices is monotonic, so equal endpoints put both n-grams in one word
+        if indices[i] == indices[i + lag + length - 1]:
             within_pairs += 1
             within_observed += matched
         else:
@@ -294,4 +303,146 @@ def boundary_permutation_test(
         null_mean=statistics.fmean(null),
         null_sd=statistics.pstdev(null),
         p_value=(at_least + 1) / (permutations + 1),
+    )
+
+
+def match_separations(
+    text: Sequence[T],
+    lag: int,
+    max_separation: int | None = None,
+) -> dict[int, int]:
+    """Histogram the separations between consecutive lag-L matches.
+
+    Where `joint_coincidence` counts pairs of matches at chosen separations,
+    this profiles the gaps between one match and the next. Under
+    independence the gaps are geometric; an excess at particular separations
+    (or a dead zone at small ones) is the higher-order signature of a
+    periodic or self-excluding mechanism. Judge significance against a
+    resampled null; the gaps are not independent.
+
+    Args:
+        text: Sequence to analyze
+        lag: Lag of the match indicator
+        max_separation: Largest separation to include; unlimited when omitted
+
+    Returns:
+        A dictionary mapping each observed separation between consecutive
+        matches to its count
+
+    Raises:
+        InvalidInputError: If lag is not a positive integer
+        InsufficientDataError: If text is no longer than lag
+    """
+    indicator = match_indicator(text, lag)
+    separations: dict[int, int] = {}
+    previous: int | None = None
+    for i, matched in enumerate(indicator):
+        if not matched:
+            continue
+        if previous is not None:
+            gap = i - previous
+            if max_separation is None or gap <= max_separation:
+                separations[gap] = separations.get(gap, 0) + 1
+        previous = i
+    return separations
+
+
+def within_delta_histogram(
+    words: Sequence[Sequence[T]],
+    alphabet: Sequence[T],
+    lag: int,
+) -> list[int]:
+    """Histogram the modular symbol difference over within-word lag-L pairs.
+
+    For every pair of positions lag apart inside a single word, counts the
+    difference of alphabet indices modulo the alphabet size. Bin 0 holds the
+    coincidences; the shape of the nonzero bins discriminates mechanisms
+    that a bare match count cannot: a literal copy inflates only bin 0,
+    additive key drift shifts mass to specific nonzero bins, and an
+    unstructured stream leaves them flat.
+
+    Args:
+        words: Tokenized text, one sequence per word
+        alphabet: The alphabet fixing the index of every symbol
+        lag: Distance between the compared symbols
+
+    Returns:
+        A list of alphabet-size counts, entry d holding the number of pairs
+        with (index(second) - index(first)) mod alphabetsize == d
+
+    Raises:
+        InvalidInputError: If lag is not a positive integer or a symbol is
+            missing from the alphabet
+    """
+    validate_positive_integer(lag, "lag")
+    index = {symbol: i for i, symbol in enumerate(alphabet)}
+    modulus = len(alphabet)
+    histogram = [0] * modulus
+    for word in words:
+        for i in range(len(word) - lag):
+            try:
+                delta = (index[word[i + lag]] - index[word[i]]) % modulus
+            except KeyError as exc:
+                msg = f"symbol {exc.args[0]!r} not in alphabet"
+                raise InvalidInputError(msg) from exc
+            histogram[delta] += 1
+    return histogram
+
+
+class BucketCoincidence(NamedTuple):
+    """Pooled pairwise coincidence within position buckets.
+
+    Attributes:
+        observed: Equal-symbol pairs found inside buckets
+        pairs: Position pairs available inside buckets
+        rate: observed / pairs, or 0.0 with no pairs
+    """
+
+    observed: int
+    pairs: int
+    rate: float
+
+
+def bucket_coincidence(
+    stream: Sequence[T],
+    labels: Sequence[object],
+) -> BucketCoincidence:
+    """Pool the pairwise coincidence rate inside arbitrary position buckets.
+
+    Every position carries a label; all unordered position pairs sharing a
+    label are compared. A pooled rate above the chance rate means positions
+    with the same label tend to hold the same symbol — the general test for
+    "is the key a function of this observable?", with the label encoding the
+    hypothesis: position within a period, word length and phase, line
+    number, or any other public feature.
+
+    Args:
+        stream: Symbol stream to analyze
+        labels: One bucket label per position; positions with equal labels
+            are compared
+
+    Returns:
+        The pooled matched pairs, available pairs, and rate
+
+    Raises:
+        InvalidInputError: If labels and stream lengths differ
+    """
+    if len(labels) != len(stream):
+        msg = f"{len(labels)} labels for {len(stream)} positions"
+        raise InvalidInputError(msg)
+    buckets: dict[object, Counter[T]] = {}
+    sizes: Counter[object] = Counter()
+    for symbol, label in zip(stream, labels):
+        buckets.setdefault(label, Counter())[symbol] += 1
+        sizes[label] += 1
+    observed = 0
+    pairs = 0
+    for label, counts in buckets.items():
+        size = sizes[label]
+        pairs += size * (size - 1) // 2
+        observed += sum(count * (count - 1) // 2 for count in counts.values())
+    return BucketCoincidence(
+        observed=observed,
+        pairs=pairs,
+        rate=observed / pairs if pairs else 0.0,
     )

--- a/src/aldegonde/analysis/fingerprint.py
+++ b/src/aldegonde/analysis/fingerprint.py
@@ -1,0 +1,108 @@
+# ABOUTME: A compact statistical fingerprint of a symbol stream, and a
+# ABOUTME: comparison against a reference (a mechanism-consistency check).
+"""Statistical fingerprint of a symbol stream.
+
+A cipher hypothesis is tested by simulating the mechanism over language-like
+plaintext and asking whether the simulated ciphertext reproduces the
+observed statistics. That comparison needs a fixed vector of discriminating
+statistics computed the same way on both sides. `fingerprint` returns that
+vector — normalized IOC, doublet rate, and a short kappa profile — and
+`compare` scores one fingerprint against a reference, so "is my ciphertext
+consistent with mechanism X?" becomes: fingerprint the real text, simulate
+X, fingerprint that, compare.
+
+The fingerprint is deliberately small and composed of existing library
+statistics; extend the returned mapping as a particular investigation needs
+more discriminating power.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+from aldegonde.exceptions import InsufficientDataError
+from aldegonde.stats.ioc import nioc
+from aldegonde.stats.kappa import kappa_spectrum
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+T = TypeVar("T")
+
+
+def fingerprint(
+    text: Sequence[T],
+    *,
+    alphabetsize: int | None = None,
+    lags: Sequence[int] = (1, 2, 3, 4, 5),
+) -> dict[str, float]:
+    """Compute a compact statistical fingerprint of a stream.
+
+    The vector holds the normalized index of coincidence (`nioc`), the
+    monographic doublet rate (`doublet_rate`), and the frequency-matched
+    kappa z at each requested lag (`kappa_z_<lag>`). All are alphabet-size
+    normalized, so fingerprints of different texts are comparable.
+
+    Args:
+        text: Sequence to fingerprint
+        alphabetsize: Alphabet size for IOC normalization; distinct-symbol
+            count when omitted
+        lags: Lags whose kappa z-scores enter the fingerprint
+
+    Returns:
+        A mapping from statistic name to value
+
+    Raises:
+        InsufficientDataError: If the text is too short for the statistics
+    """
+    if len(text) < 2:
+        msg = "fingerprint needs at least 2 symbols"
+        raise InsufficientDataError(msg, 2, len(text))
+    size = alphabetsize if alphabetsize is not None else len(set(text))
+    result: dict[str, float] = {
+        "nioc": nioc(text, alphabetsize=size).nioc,
+        "doublet_rate": sum(1 for a, b in zip(text, text[1:]) if a == b)
+        / (len(text) - 1),
+    }
+    spectrum = kappa_spectrum(text, list(lags))
+    for lag in lags:
+        hit = spectrum.get(lag)
+        result[f"kappa_z_{lag}"] = hit.z if hit is not None else 0.0
+    return result
+
+
+def compare(
+    observed: Mapping[str, float],
+    reference: Mapping[str, float],
+    *,
+    scales: Mapping[str, float] | None = None,
+) -> float:
+    """Score a fingerprint against a reference as a scaled squared distance.
+
+    Sums, over the statistics both fingerprints share, the squared
+    difference divided by a per-statistic scale (default 1.0). Smaller is a
+    closer match; a simulated mechanism whose fingerprint sits closest to
+    the observed one is the best-supported hypothesis. Supply `scales`
+    (e.g. each statistic's spread under simulation) to weight the terms
+    commensurately.
+
+    Args:
+        observed: Fingerprint of the real text
+        reference: Fingerprint to compare against
+        scales: Per-statistic divisor; 1.0 where unspecified
+
+    Returns:
+        The scaled squared distance over shared statistics
+
+    Raises:
+        InsufficientDataError: If the fingerprints share no statistics
+    """
+    shared = set(observed) & set(reference)
+    if not shared:
+        msg = "fingerprints share no statistics to compare"
+        raise InsufficientDataError(msg, 1, 0)
+    total = 0.0
+    for name in shared:
+        scale = 1.0 if scales is None else scales.get(name, 1.0)
+        total += ((observed[name] - reference[name]) / scale) ** 2
+    return total

--- a/src/aldegonde/analysis/fourpoint.py
+++ b/src/aldegonde/analysis/fourpoint.py
@@ -1,0 +1,102 @@
+# ABOUTME: Four-point coincidence statistics with closed-form nulls, the
+# ABOUTME: signature class that pairwise and single-symbol tests cannot see.
+"""Four-point coincidence statistics.
+
+Some ciphers — transposition composed with homophonic substitution, the
+Zodiac-340 family — leave no first- or second-order signature at all, yet
+constrain quadruples of positions: four positions in a fixed geometric
+relation coincide in a pattern more (or less) often than chance. This
+module counts the canonical four-point template and compares it to its
+closed-form expectation under independence.
+
+For a template of position offsets, the statistic counts the windows in
+which the two pairs (positions 0,1) and (2,3) each hold equal symbols. Under
+a uniform-independent null each pair matches with probability 1/N, so both
+match with probability 1/N^2 and the expected count is the window count over
+N^2. A scan over the template's spacing is a family of tests: read the peak
+against the whole family with a look-elsewhere correction, never a single
+cell.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple, TypeVar
+
+from aldegonde.exceptions import InsufficientDataError, InvalidInputError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+T = TypeVar("T")
+
+
+class FourPointCount(NamedTuple):
+    """A four-point coincidence count against its chance expectation.
+
+    Attributes:
+        observed: Windows where both configured pairs hold equal symbols
+        expected: Windows expected under a uniform-independent null
+        windows: Windows examined
+        z: Poisson standard score of the count against expectation
+    """
+
+    observed: int
+    expected: float
+    windows: int
+    z: float
+
+
+def fourpoint_coincidence(
+    text: Sequence[T],
+    offsets: tuple[int, int, int, int],
+    alphabetsize: int,
+) -> FourPointCount:
+    """Count windows where two configured position pairs both coincide.
+
+    For each window start i the four positions i+offsets[k] are read; the
+    window counts when the symbols at the first pair (offsets 0 and 1) are
+    equal and the symbols at the second pair (offsets 2 and 3) are equal.
+    The expectation under a uniform-independent null is the window count
+    over alphabetsize squared, and the count is standardized as a Poisson
+    score. This is the four-point generalization of the coincidence tests:
+    it registers structure that leaves every one- and two-point statistic at
+    chance.
+
+    Args:
+        text: Sequence to analyze
+        offsets: Four position offsets; the pairs (0,1) and (2,3) are tested
+            for equality
+        alphabetsize: Alphabet size fixing the chance rate
+
+    Returns:
+        The observed count, its expectation, the window count, and the z
+
+    Raises:
+        InvalidInputError: If alphabetsize < 2 or the offsets are negative
+        InsufficientDataError: If no window fits the offsets
+    """
+    if alphabetsize < 2:
+        msg = f"alphabetsize must be at least 2, got {alphabetsize}"
+        raise InvalidInputError(msg)
+    if any(offset < 0 for offset in offsets):
+        msg = f"offsets must be non-negative, got {offsets}"
+        raise InvalidInputError(msg)
+    span = max(offsets)
+    windows = len(text) - span
+    if windows < 1:
+        msg = f"text of length {len(text)} has no window for offsets {offsets}"
+        raise InsufficientDataError(msg, span + 1, len(text))
+    a, b, c, d = offsets
+    observed = 0
+    for i in range(windows):
+        if text[i + a] == text[i + b] and text[i + c] == text[i + d]:
+            observed += 1
+    expected = windows / (alphabetsize * alphabetsize)
+    sd = expected**0.5
+    z = (observed - expected) / sd if sd > 0 else 0.0
+    return FourPointCount(
+        observed=observed,
+        expected=expected,
+        windows=windows,
+        z=z,
+    )

--- a/src/aldegonde/analysis/keystream.py
+++ b/src/aldegonde/analysis/keystream.py
@@ -1,0 +1,178 @@
+# ABOUTME: Running-key attacks: offset scan with a self-calibrating empirical
+# ABOUTME: null, and the autokey depth-split detector.
+"""Running-key and autokey detection.
+
+Two attacks that recur whenever a keystream is suspected:
+
+`offset_scan` subtracts a candidate keystream from the ciphertext at every
+starting offset and scores each derived plaintext, then standardizes the
+scores against the scan's own distribution — a self-calibrating empirical
+null, so no analytic model of the score is needed. The right offset stands
+out as an outlier in the scan's own spread.
+
+`autokey_split` detects ciphertext autokey without recovering the key: it
+partitions positions by the ciphertext symbol a fixed depth back and pools
+the index of coincidence within groups. If each group is a monoalphabetic
+image of natural language — which ciphertext autokey makes it — the pooled
+IOC rises to the plaintext level, well above the flat-text value.
+
+Both are alphabet-generic; correct any offset scan for the offsets tried.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from statistics import fmean, pstdev
+from typing import NamedTuple, TypeVar
+
+from aldegonde.exceptions import InvalidInputError
+
+T = TypeVar("T")
+
+Score = Callable[[Sequence[int]], float]
+"""A plaintext score to maximize over offsets, e.g. n-gram fitness."""
+
+
+class OffsetHit(NamedTuple):
+    """One offset in a keystream scan, standardized against the scan itself.
+
+    Attributes:
+        offset: Keystream starting offset
+        score: The plaintext score at this offset
+        z: Standard score against the mean and spread of all offsets tried
+    """
+
+    offset: int
+    score: float
+    z: float
+
+
+def offset_scan(
+    cipher: Sequence[int],
+    keystream: Sequence[int],
+    modulus: int,
+    score: Score,
+    *,
+    max_offset: int | None = None,
+    subtract: bool = True,
+) -> list[OffsetHit]:
+    """Score the ciphertext against every window of a long keystream.
+
+    The keystream is at least as long as the ciphertext; at each starting
+    offset the aligned window is combined with the whole ciphertext
+    (subtracted for an additive cipher, added for Beaufort-like ones) modulo
+    the alphabet size, and the resulting plaintext is scored. Every offset's
+    score is then standardized against the mean and spread of all offsets in
+    the scan — the self-calibrating empirical null — so a genuine hit shows
+    as a large z without any analytic model of the score distribution.
+
+    Args:
+        cipher: Ciphertext as alphabet indices
+        keystream: Candidate keystream as integers (reduced modulo modulus),
+            at least as long as the ciphertext
+        modulus: Alphabet size
+        score: Plaintext scorer to maximize
+        max_offset: Largest starting offset to try; as many as fit when
+            omitted
+        subtract: Subtract the keystream (additive cipher); add it otherwise
+
+    Returns:
+        One OffsetHit per offset, in offset order
+
+    Raises:
+        InvalidInputError: If modulus is not positive, the keystream is
+            shorter than the ciphertext, or no offset fits
+    """
+    if modulus < 1:
+        msg = f"modulus must be positive, got {modulus}"
+        raise InvalidInputError(msg)
+    span = len(keystream) - len(cipher)
+    if span < 0:
+        msg = "keystream is shorter than the ciphertext"
+        raise InvalidInputError(msg)
+    last = span if max_offset is None else min(span, max_offset)
+    offsets = range(last + 1)
+    reduced = [k % modulus for k in keystream]
+    raw: list[tuple[int, float]] = []
+    for offset in offsets:
+        window = reduced[offset : offset + len(cipher)]
+        if subtract:
+            plain = [(c - k) % modulus for c, k in zip(cipher, window)]
+        else:
+            plain = [(k - c) % modulus for c, k in zip(cipher, window)]
+        raw.append((offset, score(plain)))
+    if not raw:
+        msg = "no offset fits the given max_offset"
+        raise InvalidInputError(msg)
+    scores = [value for _, value in raw]
+    mean = fmean(scores)
+    sd = pstdev(scores) if len(scores) > 1 else 0.0
+    return [
+        OffsetHit(offset=offset, score=value, z=(value - mean) / sd if sd else 0.0)
+        for offset, value in raw
+    ]
+
+
+class AutokeySplit(NamedTuple):
+    """Pooled within-group coincidence of an autokey depth split.
+
+    Attributes:
+        depth: The feedback depth tested
+        pooled_ioc: Normalized IOC pooled across groups keyed on the symbol
+            `depth` positions back
+        groups: Number of non-empty groups
+    """
+
+    depth: int
+    pooled_ioc: float
+    groups: int
+
+
+def autokey_split(
+    cipher: Sequence[T],
+    depth: int,
+    alphabetsize: int | None = None,
+) -> AutokeySplit:
+    """Pool the coincidence within groups keyed on an earlier symbol.
+
+    Partitions the positions from index `depth` on by the ciphertext symbol
+    `depth` positions back, then pools the index of coincidence across those
+    groups (summing matching-pair and total-pair counts, not averaging
+    per-group rates, so unequal groups combine correctly). Under a
+    ciphertext autokey of that depth each group is a monoalphabetic image of
+    the plaintext, so the pooled normalized IOC climbs toward the plaintext
+    value (well above 1.0); flat text leaves it near 1.0.
+
+    Args:
+        cipher: Ciphertext stream
+        depth: Feedback depth to test
+        alphabetsize: Alphabet size for normalization; the count of distinct
+            symbols when omitted
+
+    Returns:
+        The pooled normalized IOC and the group count for this depth
+
+    Raises:
+        InvalidInputError: If depth is not positive
+    """
+    if depth < 1:
+        msg = f"depth must be positive, got {depth}"
+        raise InvalidInputError(msg)
+    if alphabetsize is None:
+        alphabetsize = len(set(cipher))
+    groups: dict[T, dict[T, int]] = {}
+    sizes: dict[T, int] = {}
+    for i in range(depth, len(cipher)):
+        key = cipher[i - depth]
+        bucket = groups.setdefault(key, {})
+        symbol = cipher[i]
+        bucket[symbol] = bucket.get(symbol, 0) + 1
+        sizes[key] = sizes.get(key, 0) + 1
+    matches = 0
+    pairs = 0
+    for key, bucket in groups.items():
+        size = sizes[key]
+        pairs += size * (size - 1)
+        matches += sum(count * (count - 1) for count in bucket.values())
+    pooled = (alphabetsize * matches / pairs) if pairs else 0.0
+    return AutokeySplit(depth=depth, pooled_ioc=pooled, groups=len(groups))

--- a/src/aldegonde/analysis/relations.py
+++ b/src/aldegonde/analysis/relations.py
@@ -1,0 +1,126 @@
+# ABOUTME: Scans for linear and positional relations between symbols at a lag,
+# ABOUTME: the omnibus detector for affine, LFSR, and drifting-key structure.
+"""Linear-relation scans over a modular alphabet.
+
+If a cipher relates a symbol to an earlier one linearly — Vigenere and
+Beaufort make x[i+d] +/- x[i] constant per key position, an affine step
+makes a*x[i] + x[i+d] structured, a lagged-Fibonacci keystream makes some
+tap combination degenerate — then the derived stream
+(x[i+d] + a*x[i]) mod N is non-uniform for the right (d, a). Scanning
+lags against coefficients and chi-squaring each derived stream for
+uniformity detects that whole family at once; the positional variant
+(x[i] + a*i) mod N catches keys that drift linearly with the position.
+
+Every cell of the scan is one test: read results through
+`stats.multitest` (Bonferroni over the grid size) or confirm a hit with a
+resampled null before believing it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+from aldegonde.exceptions import InvalidInputError
+from aldegonde.stats.chisq import ChiSquare, uniformity
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+T = TypeVar("T")
+
+
+def _indices(text: Sequence[T], alphabet: Sequence[T]) -> list[int]:
+    """Map a sequence to alphabet indices."""
+    index = {symbol: i for i, symbol in enumerate(alphabet)}
+    try:
+        return [index[symbol] for symbol in text]
+    except KeyError as exc:
+        msg = f"symbol {exc.args[0]!r} not in alphabet"
+        raise InvalidInputError(msg) from exc
+
+
+def linear_relation_scan(
+    text: Sequence[T],
+    alphabet: Sequence[T],
+    lags: Sequence[int],
+    coefficients: Sequence[int] | None = None,
+) -> dict[tuple[int, int], ChiSquare]:
+    """Chi-square the derived streams (x[i+d] + a*x[i]) mod N for uniformity.
+
+    A significant cell at (d, a) means the symbol at distance d carries a
+    linear relation with coefficient a — the signature of additive keys,
+    affine steps, and linear-recurrence keystreams. The scan has
+    len(lags) * len(coefficients) cells; correct for that with
+    `stats.multitest.bonferroni` before reading any single cell.
+
+    Args:
+        text: Sequence to analyze
+        alphabet: The alphabet fixing symbol indices and the modulus N
+        lags: Lags d to scan
+        coefficients: Coefficients a to scan; 1..N-1 when omitted
+
+    Returns:
+        A ChiSquare per (lag, coefficient) cell that admits at least two
+        pairs
+
+    Raises:
+        InvalidInputError: If a lag is not positive or a symbol is missing
+            from the alphabet
+    """
+    numbers = _indices(text, alphabet)
+    modulus = len(alphabet)
+    scan_coefficients = (
+        list(coefficients) if coefficients is not None else list(range(1, modulus))
+    )
+    results: dict[tuple[int, int], ChiSquare] = {}
+    for lag in lags:
+        if lag < 1:
+            msg = f"lag must be positive, got {lag}"
+            raise InvalidInputError(msg)
+        pairs = len(numbers) - lag
+        if pairs < 2:
+            continue
+        for coefficient in scan_coefficients:
+            counts = [0] * modulus
+            for i in range(pairs):
+                counts[(numbers[i + lag] + coefficient * numbers[i]) % modulus] += 1
+            results[(lag, coefficient)] = uniformity(counts)
+    return results
+
+
+def positional_relation_scan(
+    text: Sequence[T],
+    alphabet: Sequence[T],
+    coefficients: Sequence[int] | None = None,
+) -> dict[int, ChiSquare]:
+    """Chi-square the derived streams (x[i] + a*i) mod N for uniformity.
+
+    A significant coefficient a means the symbols carry a component linear
+    in their position — a progressively shifting key, a counter mixed into
+    the cipher, or a positional drift. One test per coefficient: correct
+    with `stats.multitest` over the scan size.
+
+    Args:
+        text: Sequence to analyze
+        alphabet: The alphabet fixing symbol indices and the modulus N
+        coefficients: Coefficients a to scan; 1..N-1 when omitted
+
+    Returns:
+        A ChiSquare per coefficient
+
+    Raises:
+        InvalidInputError: If a symbol is missing from the alphabet
+        InsufficientDataError: If the text is empty
+    """
+    numbers = _indices(text, alphabet)
+    modulus = len(alphabet)
+    scan_coefficients = (
+        list(coefficients) if coefficients is not None else list(range(1, modulus))
+    )
+    results: dict[int, ChiSquare] = {}
+    for coefficient in scan_coefficients:
+        counts = [0] * modulus
+        for i, number in enumerate(numbers):
+            counts[(number + coefficient * i) % modulus] += 1
+        results[coefficient] = uniformity(counts)
+    return results

--- a/src/aldegonde/analysis/spectral.py
+++ b/src/aldegonde/analysis/spectral.py
@@ -1,0 +1,201 @@
+# ABOUTME: Spectral and cross-correlation detectors: keystream-reuse alignment
+# ABOUTME: by FFT, and multiplier-DFT periodicity for arbitrary modulus.
+"""Spectral detectors for structure that lag statistics miss.
+
+Two Fourier-based probes over a symbol stream:
+
+`crosscorrelation_coincidence` finds the alignment at which two streams
+coincide most, in O(n log n), by summing the circular cross-correlation of
+their per-symbol indicator vectors. It detects a shared or reused keystream
+between two messages at every relative shift at once, where a pairwise lag
+scan would cost O(n^2).
+
+`multiplier_dft` detects additive periodic structure at periods that need
+not be integers. For each nonzero multiplier m it takes the DFT of
+exp(2*pi*i*m*x/N) over the alphabet indices; a spike at frequency f exposes
+a component whose phase advances by m*f per step. Under the null each
+power is exponentially distributed, so the peak is read against a threshold
+that counts the whole multiplier-by-frequency scan. Integer-lag kappa and
+Kasiski cannot see a non-integer period; this can.
+"""
+
+from __future__ import annotations
+
+from math import log
+from typing import TYPE_CHECKING, NamedTuple, TypeVar
+
+import numpy as np
+
+from aldegonde.exceptions import InsufficientDataError, InvalidInputError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+T = TypeVar("T")
+
+
+class AlignmentPeak(NamedTuple):
+    """The strongest coincidence alignment between two streams.
+
+    Attributes:
+        shift: Cyclic shift maximizing coincidences, in the convention that
+            first[i] aligns with second[(i + shift) mod n]; normalized to
+            the range (-n/2, n/2]
+        coincidences: Matching positions at that shift
+        expected: Coincidences expected by chance at that overlap
+        z: Binomial standard score of the peak against chance
+    """
+
+    shift: int
+    coincidences: int
+    expected: float
+    z: float
+
+
+def crosscorrelation_coincidence(
+    first: Sequence[T],
+    second: Sequence[T],
+    alphabet: Sequence[T],
+) -> AlignmentPeak:
+    """Find the shift where two streams coincide most, by FFT.
+
+    Sums the circular cross-correlation of the per-symbol indicator vectors
+    of the two streams, giving the coincidence count at every cyclic shift
+    in O(n log n). The best shift and its binomial z against the chance rate
+    1/alphabetsize are returned — the reused-keystream / running-key-depth
+    detector, at every alignment at once.
+
+    Args:
+        first: First stream
+        second: Second stream, cyclically shifted against the first
+        alphabet: The alphabet fixing symbol indices
+
+    Returns:
+        The peak alignment, its coincidence count, chance expectation, and z
+
+    Raises:
+        InvalidInputError: If the streams differ in length or a symbol is
+            missing from the alphabet
+        InsufficientDataError: If the streams are empty
+    """
+    if len(first) != len(second):
+        msg = f"streams differ in length: {len(first)} vs {len(second)}"
+        raise InvalidInputError(msg)
+    n = len(first)
+    if n == 0:
+        msg = "crosscorrelation_coincidence needs non-empty streams"
+        raise InsufficientDataError(msg, 1, 0)
+    index = {symbol: i for i, symbol in enumerate(alphabet)}
+    size = len(alphabet)
+    try:
+        a = np.array([index[s] for s in first])
+        b = np.array([index[s] for s in second])
+    except KeyError as exc:
+        msg = f"symbol {exc.args[0]!r} not in alphabet"
+        raise InvalidInputError(msg) from exc
+    correlation = np.zeros(n)
+    for symbol in range(size):
+        indicator_a = (a == symbol).astype(float)
+        indicator_b = (b == symbol).astype(float)
+        spectrum = np.fft.rfft(indicator_a) * np.conj(np.fft.rfft(indicator_b))
+        correlation += np.fft.irfft(spectrum, n)
+    peak = int(np.argmax(correlation))
+    coincidences = int(round(correlation[peak]))
+    # irfft(rfft(a) * conj(rfft(b)))[k] sums a[i] b[(i - k) mod n]; the
+    # aligning shift in the first[i] ~ second[i + shift] convention is -k,
+    # normalized to (-n/2, n/2] for readability
+    shift = (n - peak) % n
+    if shift > n // 2:
+        shift -= n
+    expected = n / size
+    sd = (n * (1.0 / size) * (1.0 - 1.0 / size)) ** 0.5
+    z = (coincidences - expected) / sd if sd > 0 else 0.0
+    return AlignmentPeak(
+        shift=shift,
+        coincidences=coincidences,
+        expected=expected,
+        z=z,
+    )
+
+
+class SpectralPeak(NamedTuple):
+    """The strongest multiplier-DFT peak of a stream.
+
+    Attributes:
+        multiplier: The multiplier m attaining the peak
+        frequency: The DFT bin index of the peak
+        power: Normalized power at the peak (mean 1 under the null)
+        threshold: The log(cells) + 3 significance level, where cells counts
+            every (multiplier, nonzero frequency) bin scanned
+    """
+
+    multiplier: int
+    frequency: int
+    power: float
+    threshold: float
+
+
+def multiplier_dft(
+    text: Sequence[T],
+    alphabet: Sequence[T],
+    multipliers: Sequence[int] | None = None,
+) -> SpectralPeak:
+    """Find the strongest additive-periodic component across all multipliers.
+
+    For each multiplier m the stream indices are mapped to unit phasors
+    exp(2*pi*i*m*x/N) and transformed; the power spectrum is normalized to
+    unit mean, so under the null each bin is exponentially distributed. The
+    largest normalized power over all multipliers and nonzero frequencies is
+    returned with a max-of-bins threshold of log(bins) + 3 — clearing it
+    signals a periodic component (possibly at a non-integer period) that
+    integer-lag tests miss.
+
+    Args:
+        text: Sequence to analyze
+        alphabet: The alphabet fixing symbol indices and the modulus N
+        multipliers: Multipliers m to scan; 1..N-1 when omitted
+
+    Returns:
+        The peak multiplier, frequency, normalized power, and threshold
+
+    Raises:
+        InvalidInputError: If a symbol is missing from the alphabet
+        InsufficientDataError: If the text has fewer than 2 symbols
+    """
+    n = len(text)
+    if n < 2:
+        msg = "multiplier_dft needs at least 2 symbols"
+        raise InsufficientDataError(msg, 2, n)
+    modulus = len(alphabet)
+    index = {symbol: i for i, symbol in enumerate(alphabet)}
+    try:
+        values = np.array([index[s] for s in text], dtype=float)
+    except KeyError as exc:
+        msg = f"symbol {exc.args[0]!r} not in alphabet"
+        raise InvalidInputError(msg) from exc
+    scan = list(multipliers) if multipliers is not None else list(range(1, modulus))
+    # The peak is a maximum over every (multiplier, nonzero frequency) cell,
+    # so the exponential-tail threshold must count the whole family, not one
+    # spectrum's bins.
+    cells = len(scan) * (n - 1)
+    threshold = log(cells) + 3.0 if cells > 0 else 0.0
+    best = SpectralPeak(multiplier=0, frequency=0, power=0.0, threshold=threshold)
+    for multiplier in scan:
+        phasors = np.exp(2j * np.pi * multiplier * values / modulus)
+        spectrum = np.fft.fft(phasors)
+        power = np.abs(spectrum) ** 2
+        mean = power.mean()
+        if mean <= 0:
+            continue
+        normalized = power / mean
+        # Skip the zero-frequency (DC) bin: it only reflects the mean phasor
+        frequency = int(np.argmax(normalized[1:])) + 1
+        peak = float(normalized[frequency])
+        if peak > best.power:
+            best = SpectralPeak(
+                multiplier=multiplier,
+                frequency=frequency,
+                power=peak,
+                threshold=threshold,
+            )
+    return best

--- a/src/aldegonde/c3301.py
+++ b/src/aldegonde/c3301.py
@@ -153,6 +153,32 @@ def low_doublet_null() -> nulls.NullModel[int]:
     return model
 
 
+def low_doublet_markov_null() -> nulls.NullModel[int]:
+    """Generative null matching the text's own doublet rate over the 29 runes.
+
+    The generative twin of `low_doublet_null`: instead of rearranging the
+    observed runes, each surrogate is drawn fresh from a uniform-marginal
+    Markov chain whose self-transition probability equals the observed
+    doublet rate (see `stats.nulls.doublet_markov`). Use this when the null
+    hypothesis is "a random rune process with the Liber Primus doublet
+    suppression and nothing else"; use `low_doublet_null` when the observed
+    rune frequencies must be held exactly.
+
+    Returns:
+        A null model generating length-matched rune-index surrogates at the
+        observed doublet rate
+    """
+
+    def model(data: Sequence[int], rng: random.Random) -> Sequence[int]:
+        rate = _observed_doublet_rate(data)
+        sampler: nulls.NullModel[int] = nulls.doublet_markov(
+            list(range(len(CICADA_ALPHABET))), rate
+        )
+        return sampler(data, rng)
+
+    return model
+
+
 def numberToBase(n: int, b: int) -> list[int]:
     """Convert from base10 to any other base. outputs as list of int."""
     if n == 0:

--- a/src/aldegonde/maths/__init__.py
+++ b/src/aldegonde/maths/__init__.py
@@ -4,6 +4,17 @@ from aldegonde.maths.factor import factor_pairs, prime_factors
 from aldegonde.maths.modular import div29, modDivide, modInverse
 from aldegonde.maths.moebius import isPrime, moebius
 from aldegonde.maths.primes import PrimeGenerator, gen_primes_opt, primes
+from aldegonde.maths.sequences import (
+    catalogue,
+    fibonacci,
+    linear_recurrence,
+    lucas,
+    moebius_sequence,
+    naturals,
+    polygonal,
+    prime_gaps,
+    triangular,
+)
 from aldegonde.maths.totient import gcd, is_coprime, phi_func
 
 __all__ = [
@@ -21,6 +32,16 @@ __all__ = [
     "PrimeGenerator",
     "gen_primes_opt",
     "primes",
+    # sequences
+    "catalogue",
+    "fibonacci",
+    "linear_recurrence",
+    "lucas",
+    "moebius_sequence",
+    "naturals",
+    "polygonal",
+    "prime_gaps",
+    "triangular",
     # totient
     "gcd",
     "is_coprime",

--- a/src/aldegonde/maths/sequences.py
+++ b/src/aldegonde/maths/sequences.py
@@ -1,0 +1,188 @@
+# ABOUTME: Integer-sequence generators for keystream hypotheses: primes,
+# ABOUTME: totient, figurate, and linear-recurrence families, length-bounded.
+"""Integer sequences used as running keys.
+
+A running-key attack tries a deterministic integer sequence as the
+keystream: primes, Euler totients, Fibonacci, the triangular numbers, and
+so on. This module generates the first `n` terms of each as plain integers;
+reduce them modulo the alphabet size at the point of use. The generators
+are length-bounded (not infinite) so a scan over families and offsets stays
+finite, and `catalogue` bundles the common families behind one name so an
+attack can sweep them all.
+
+These are the sequences themselves, not the attack: pair them with a
+keystream subtraction scan and a proper multiple-comparison correction.
+"""
+
+from __future__ import annotations
+
+from aldegonde.exceptions import InvalidInputError
+from aldegonde.maths.moebius import moebius
+from aldegonde.maths.primes import primes as _primes_up_to
+from aldegonde.maths.totient import phi_func
+
+
+def _validate_n(n: int) -> None:
+    if n < 0:
+        msg = f"n must be non-negative, got {n}"
+        raise InvalidInputError(msg)
+
+
+def naturals(n: int, start: int = 0) -> list[int]:
+    """Return n consecutive integers from `start` (the index sequence)."""
+    _validate_n(n)
+    return list(range(start, start + n))
+
+
+def primes(n: int) -> list[int]:
+    """Return the first n prime numbers."""
+    _validate_n(n)
+    if n == 0:
+        return []
+    # Overestimate the bound: the nth prime is below n(ln n + ln ln n) for
+    # n >= 6, with a small floor for the first few.
+    from math import log
+
+    bound = 15 if n < 6 else int(n * (log(n) + log(log(n))) + 3)
+    found = _primes_up_to(bound)
+    while len(found) < n:
+        bound *= 2
+        found = _primes_up_to(bound)
+    return found[:n]
+
+
+def prime_gaps(n: int) -> list[int]:
+    """Return the first n gaps between consecutive primes."""
+    _validate_n(n)
+    if n == 0:
+        return []
+    ps = primes(n + 1)
+    return [ps[i + 1] - ps[i] for i in range(n)]
+
+
+def totients(n: int, start: int = 1) -> list[int]:
+    """Return Euler's totient phi(k) for n integers k from `start`."""
+    _validate_n(n)
+    if start < 1:
+        msg = f"totient start must be positive, got {start}"
+        raise InvalidInputError(msg)
+    return [phi_func(k) for k in range(start, start + n)]
+
+
+def moebius_sequence(n: int, start: int = 1) -> list[int]:
+    """Return the Moebius function mu(k) for n integers k from `start`."""
+    _validate_n(n)
+    if start < 1:
+        msg = f"moebius start must be positive, got {start}"
+        raise InvalidInputError(msg)
+    return [moebius(k) for k in range(start, start + n)]
+
+
+def triangular(n: int) -> list[int]:
+    """Return the first n triangular numbers k(k+1)/2, from k = 1."""
+    _validate_n(n)
+    return [k * (k + 1) // 2 for k in range(1, n + 1)]
+
+
+def polygonal(n: int, sides: int) -> list[int]:
+    """Return the first n polygonal numbers with the given side count.
+
+    Sides 3 gives triangular numbers, 4 the squares, 5 the pentagonal
+    numbers, and so on.
+
+    Args:
+        n: Number of terms
+        sides: Polygon side count (>= 3)
+
+    Returns:
+        The first n s-gonal numbers, from k = 1
+
+    Raises:
+        InvalidInputError: If n is negative or sides < 3
+    """
+    _validate_n(n)
+    if sides < 3:
+        msg = f"sides must be at least 3, got {sides}"
+        raise InvalidInputError(msg)
+    return [((sides - 2) * k * k - (sides - 4) * k) // 2 for k in range(1, n + 1)]
+
+
+def linear_recurrence(
+    n: int,
+    seed: list[int],
+    coefficients: list[int],
+) -> list[int]:
+    """Return n terms of a linear recurrence over the integers.
+
+    Term k is the dot product of the given coefficients with the previous
+    len(seed) terms: x[k] = sum(coefficients[j] * x[k-1-j]). Fibonacci is
+    seed [0, 1] with coefficients [1, 1]; Lucas is seed [2, 1]; a tribonacci
+    is seed [0, 0, 1] with coefficients [1, 1, 1].
+
+    Args:
+        n: Number of terms
+        seed: Initial terms; also fixes the recurrence order
+        coefficients: One coefficient per previous term, most recent first
+
+    Returns:
+        The first n terms, starting from the seed
+
+    Raises:
+        InvalidInputError: If n is negative, the seed is empty, or the
+            coefficient count differs from the seed length
+    """
+    _validate_n(n)
+    if not seed:
+        msg = "linear_recurrence needs a non-empty seed"
+        raise InvalidInputError(msg)
+    if len(coefficients) != len(seed):
+        msg = f"{len(coefficients)} coefficients for order-{len(seed)} recurrence"
+        raise InvalidInputError(msg)
+    if n <= len(seed):
+        return list(seed[:n])
+    out = list(seed)
+    order = len(seed)
+    for _ in range(n - order):
+        out.append(sum(coefficients[j] * out[-1 - j] for j in range(order)))
+    return out
+
+
+def fibonacci(n: int) -> list[int]:
+    """Return the first n Fibonacci numbers, from 0, 1."""
+    return linear_recurrence(n, [0, 1], [1, 1])
+
+
+def lucas(n: int) -> list[int]:
+    """Return the first n Lucas numbers, from 2, 1."""
+    return linear_recurrence(n, [2, 1], [1, 1])
+
+
+def catalogue(n: int) -> dict[str, list[int]]:
+    """Return a bundle of common keystream sequences, each of length n.
+
+    A convenience for scanning every family at once: the keys name the
+    sequence, the values are the first n integer terms (reduce modulo the
+    alphabet at use). Extend or subset it as an attack requires.
+
+    Args:
+        n: Number of terms per sequence
+
+    Returns:
+        A mapping from sequence name to its first n terms
+
+    Raises:
+        InvalidInputError: If n is negative
+    """
+    _validate_n(n)
+    return {
+        "naturals": naturals(n),
+        "primes": primes(n),
+        "prime_gaps": prime_gaps(n),
+        "totients": totients(n),
+        "moebius": moebius_sequence(n),
+        "triangular": triangular(n),
+        "squares": polygonal(n, 4),
+        "pentagonal": polygonal(n, 5),
+        "fibonacci": fibonacci(n),
+        "lucas": lucas(n),
+    }

--- a/src/aldegonde/perm.py
+++ b/src/aldegonde/perm.py
@@ -1,0 +1,301 @@
+# ABOUTME: Permutation algebra over index form: composition, powers, order,
+# ABOUTME: parity, cycle structure, conjugation, and alphabet-key conversion.
+"""Permutation algebra for rotor, gear, and progressive cipher work.
+
+A permutation is represented in index form: a list of length n holding each of
+0..n-1 exactly once, where perm[i] is the image of i. Monoalphabetic keys over
+an arbitrary alphabet convert to and from this form with `from_key` and
+`to_key`, so the algebra stays integer-only while the ciphers stay
+alphabet-generic.
+
+Conventions:
+    compose(f, g) applies g first: compose(f, g)[i] == f[g[i]]
+    power(p, 0) is the identity; negative exponents use the inverse
+    parity is +1 for even permutations, -1 for odd
+    cycles are rotated to start at their smallest element and sorted by it,
+    and include fixed points, so cycle output is canonical
+"""
+
+from __future__ import annotations
+
+from math import lcm
+from typing import TYPE_CHECKING, TypeVar
+
+from aldegonde.exceptions import InvalidInputError
+
+if TYPE_CHECKING:
+    import random
+    from collections.abc import Mapping, Sequence
+
+T = TypeVar("T")
+
+Permutation = list[int]
+"""A permutation in index form: perm[i] is the image of i."""
+
+
+def validate_permutation(perm: Sequence[int]) -> None:
+    """Reject a sequence that is not a permutation of 0..n-1.
+
+    Args:
+        perm: Candidate permutation in index form
+
+    Raises:
+        InvalidInputError: If the sequence is not a bijection on 0..n-1
+    """
+    if sorted(perm) != list(range(len(perm))):
+        msg = f"not a permutation of 0..{len(perm) - 1}: {list(perm)!r}"
+        raise InvalidInputError(msg)
+
+
+def identity(n: int) -> Permutation:
+    """Return the identity permutation on n points."""
+    return list(range(n))
+
+
+def compose(f: Sequence[int], g: Sequence[int]) -> Permutation:
+    """Compose two permutations, applying g first.
+
+    Args:
+        f: Outer permutation
+        g: Inner permutation, applied first
+
+    Returns:
+        The permutation mapping i to f[g[i]]
+
+    Raises:
+        InvalidInputError: If the permutations act on different point counts
+    """
+    if len(f) != len(g):
+        msg = f"cannot compose permutations of sizes {len(f)} and {len(g)}"
+        raise InvalidInputError(msg)
+    return [f[g[i]] for i in range(len(g))]
+
+
+def invert(perm: Sequence[int]) -> Permutation:
+    """Return the inverse permutation."""
+    inverse = [0] * len(perm)
+    for i, image in enumerate(perm):
+        inverse[image] = i
+    return inverse
+
+
+def power(perm: Sequence[int], exponent: int) -> Permutation:
+    """Return the permutation raised to an integer power.
+
+    Exponent 0 gives the identity; negative exponents are powers of the
+    inverse. Uses binary exponentiation, so large exponents are cheap.
+
+    Args:
+        perm: Permutation in index form
+        exponent: Any integer
+
+    Returns:
+        The permutation composed with itself exponent times
+    """
+    base = list(perm) if exponent >= 0 else invert(perm)
+    remaining = abs(exponent)
+    result = identity(len(perm))
+    while remaining:
+        if remaining & 1:
+            result = compose(base, result)
+        base = compose(base, base)
+        remaining >>= 1
+    return result
+
+
+def cycles(perm: Sequence[int]) -> list[list[int]]:
+    """Return the cycle decomposition, including fixed points.
+
+    Each cycle is rotated to start at its smallest element and the cycles are
+    sorted by that element, so equal permutations yield identical output.
+
+    Args:
+        perm: Permutation in index form
+
+    Returns:
+        The cycles as lists of points
+    """
+    seen = [False] * len(perm)
+    result: list[list[int]] = []
+    for start in range(len(perm)):
+        if seen[start]:
+            continue
+        cycle = [start]
+        seen[start] = True
+        point = perm[start]
+        while point != start:
+            cycle.append(point)
+            seen[point] = True
+            point = perm[point]
+        result.append(cycle)
+    return result
+
+
+def cycle_type(perm: Sequence[int]) -> tuple[int, ...]:
+    """Return the cycle lengths, sorted descending.
+
+    The cycle type is the conjugacy invariant: two permutations are conjugate
+    exactly when their cycle types match.
+    """
+    return tuple(sorted((len(cycle) for cycle in cycles(perm)), reverse=True))
+
+
+def order(perm: Sequence[int]) -> int:
+    """Return the order: the smallest k >= 1 with perm^k the identity.
+
+    The order is the least common multiple of the cycle lengths.
+    """
+    return lcm(*(len(cycle) for cycle in cycles(perm))) if len(perm) else 1
+
+
+def parity(perm: Sequence[int]) -> int:
+    """Return +1 for an even permutation, -1 for an odd one.
+
+    A cycle of length L contributes L - 1 transpositions, so the sign is
+    (-1) ** (n - number_of_cycles). The sign is multiplicative under
+    composition, which makes it a cheap necessary condition: a product of
+    permutations can only be the identity if its total parity is even.
+    """
+    return 1 if (len(perm) - len(cycles(perm))) % 2 == 0 else -1
+
+
+def from_cycles(point_cycles: Sequence[Sequence[int]], n: int) -> Permutation:
+    """Build a permutation on n points from its cycles.
+
+    Points not mentioned in any cycle are fixed.
+
+    Args:
+        point_cycles: Cycles as sequences of points in 0..n-1
+        n: Number of points
+
+    Returns:
+        The permutation in index form
+
+    Raises:
+        InvalidInputError: If a point is out of range or appears twice
+    """
+    perm = identity(n)
+    used: set[int] = set()
+    for cycle in point_cycles:
+        for point in cycle:
+            if not 0 <= point < n:
+                msg = f"cycle point {point} out of range 0..{n - 1}"
+                raise InvalidInputError(msg)
+            if point in used:
+                msg = f"cycle point {point} appears more than once"
+                raise InvalidInputError(msg)
+            used.add(point)
+        for i, point in enumerate(cycle):
+            perm[point] = cycle[(i + 1) % len(cycle)]
+    return perm
+
+
+def from_cycle_type(lengths: Sequence[int], n: int) -> Permutation:
+    """Build the canonical permutation on n points with the given cycle type.
+
+    Points 0..n-1 are filled into cycles of the given lengths in order;
+    lengths that do not sum to n leave the remaining points fixed. Combine
+    with `conjugate` by a random permutation to sample the conjugacy class.
+
+    Args:
+        lengths: Desired cycle lengths
+        n: Number of points
+
+    Returns:
+        A permutation with exactly the given cycle type
+
+    Raises:
+        InvalidInputError: If a length is not positive or the lengths overrun n
+    """
+    total = 0
+    point_cycles: list[list[int]] = []
+    for length in lengths:
+        if length < 1:
+            msg = f"cycle length must be positive, got {length}"
+            raise InvalidInputError(msg)
+        point_cycles.append(list(range(total, total + length)))
+        total += length
+    if total > n:
+        msg = f"cycle lengths sum to {total}, more than {n} points"
+        raise InvalidInputError(msg)
+    return from_cycles(point_cycles, n)
+
+
+def conjugate(perm: Sequence[int], by: Sequence[int]) -> Permutation:
+    """Return the conjugate by ∘ perm ∘ by⁻¹.
+
+    Conjugation relabels the points of perm by the permutation `by`,
+    preserving the cycle type. It is the move that explores a conjugacy class
+    without leaving it.
+    """
+    return compose(compose(list(by), list(perm)), invert(by))
+
+
+def transposition_conjugate(perm: Sequence[int], a: int, b: int) -> Permutation:
+    """Conjugate by the transposition (a b): swap two points' roles.
+
+    The canonical cycle-type-preserving mutation for hill-climbing over a
+    conjugacy class: one call swaps the labels a and b everywhere in the
+    cycle structure and changes nothing else.
+
+    Args:
+        perm: Permutation in index form
+        a: First point
+        b: Second point
+
+    Returns:
+        The mutated permutation, with the same cycle type
+    """
+    swap = identity(len(perm))
+    swap[a], swap[b] = swap[b], swap[a]
+    return conjugate(perm, swap)
+
+
+def random_permutation(n: int, rng: random.Random) -> Permutation:
+    """Return a uniform random permutation on n points from an injected source."""
+    perm = identity(n)
+    rng.shuffle(perm)
+    return perm
+
+
+def from_key(alphabet: Sequence[T], key: Mapping[T, T]) -> Permutation:
+    """Convert a monoalphabetic substitution key to index form.
+
+    Args:
+        alphabet: The alphabet fixing the index of every symbol
+        key: Mapping from plaintext symbol to ciphertext symbol
+
+    Returns:
+        The permutation with perm[i] the index of key[alphabet[i]]
+
+    Raises:
+        InvalidInputError: If the key is not a bijection on the alphabet
+    """
+    index = {symbol: i for i, symbol in enumerate(alphabet)}
+    try:
+        perm = [index[key[symbol]] for symbol in alphabet]
+    except KeyError as exc:
+        msg = f"key is not a bijection on the alphabet: missing {exc.args[0]!r}"
+        raise InvalidInputError(msg) from exc
+    validate_permutation(perm)
+    return perm
+
+
+def to_key(alphabet: Sequence[T], perm: Sequence[int]) -> dict[T, T]:
+    """Convert a permutation in index form to a monoalphabetic key.
+
+    Args:
+        alphabet: The alphabet fixing the index of every symbol
+        perm: Permutation in index form
+
+    Returns:
+        The key mapping alphabet[i] to alphabet[perm[i]]
+
+    Raises:
+        InvalidInputError: If perm is not a permutation of the alphabet indices
+    """
+    validate_permutation(perm)
+    if len(perm) != len(alphabet):
+        msg = f"permutation size {len(perm)} != alphabet size {len(alphabet)}"
+        raise InvalidInputError(msg)
+    return {alphabet[i]: alphabet[perm[i]] for i in range(len(perm))}

--- a/src/aldegonde/search/__init__.py
+++ b/src/aldegonde/search/__init__.py
@@ -1,0 +1,27 @@
+"""Key-space search: hill climbing and filter cascades."""
+
+from aldegonde.search.cascade import Stage, StageReport, filter_cascade
+from aldegonde.search.hillclimb import (
+    ClimbResult,
+    Neighbor,
+    Score,
+    conjugation_neighbor,
+    hill_climb,
+    multi_start,
+    swap_neighbor,
+)
+
+__all__ = [
+    # cascade
+    "Stage",
+    "StageReport",
+    "filter_cascade",
+    # hillclimb
+    "ClimbResult",
+    "Neighbor",
+    "Score",
+    "conjugation_neighbor",
+    "hill_climb",
+    "multi_start",
+    "swap_neighbor",
+]

--- a/src/aldegonde/search/cascade.py
+++ b/src/aldegonde/search/cascade.py
@@ -1,0 +1,73 @@
+# ABOUTME: Cheap-to-expensive filter cascade over a candidate key space,
+# ABOUTME: reporting the survivor funnel at every stage.
+"""Staged filtering of candidate keys.
+
+Enumerated key families are best culled by a cascade: order the tests from
+cheapest to most expensive, let each stage eliminate what it can, and only
+pay for the expensive scoring on the few survivors. The funnel — how many
+candidates each stage passed — is itself the result worth reporting: a
+stage that eliminates nothing is dead weight, and a cascade that eliminates
+everything deserves a self-test before the conclusion is believed (plant a
+known key, confirm the cascade passes it; a cascade that rejects the true
+key proves only its own brokenness).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, NamedTuple, TypeVar
+
+from aldegonde.exceptions import InvalidInputError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+S = TypeVar("S")
+
+Stage = tuple[str, Callable[[S], bool]]
+"""A named predicate: candidates failing it are eliminated."""
+
+
+class StageReport(NamedTuple):
+    """Survivor count after one cascade stage.
+
+    Attributes:
+        name: The stage's name
+        entered: Candidates that reached this stage
+        survived: Candidates that passed it
+    """
+
+    name: str
+    entered: int
+    survived: int
+
+
+def filter_cascade(
+    candidates: Iterable[S],
+    stages: Sequence[Stage[S]],
+) -> tuple[list[S], list[StageReport]]:
+    """Run candidates through named predicate stages, cheapest first.
+
+    Every candidate is evaluated stage by stage and dropped at its first
+    failure, so later (more expensive) stages only see earlier survivors.
+
+    Args:
+        candidates: The candidate states to filter
+        stages: Named predicates in evaluation order
+
+    Returns:
+        The candidates surviving every stage, and a per-stage funnel report
+
+    Raises:
+        InvalidInputError: If no stages are given
+    """
+    if not stages:
+        msg = "filter_cascade needs at least one stage"
+        raise InvalidInputError(msg)
+    survivors = list(candidates)
+    reports: list[StageReport] = []
+    for name, predicate in stages:
+        entered = len(survivors)
+        survivors = [candidate for candidate in survivors if predicate(candidate)]
+        reports.append(StageReport(name=name, entered=entered, survived=len(survivors)))
+    return survivors, reports

--- a/src/aldegonde/search/hillclimb.py
+++ b/src/aldegonde/search/hillclimb.py
@@ -1,0 +1,217 @@
+# ABOUTME: Generic hill-climbing solver: injected neighborhood and score,
+# ABOUTME: stagnation cutoff, and a seeded multi-start driver.
+"""Hill climbing over an arbitrary key space.
+
+The climber is generic over the state type: the caller injects a scoring
+function (n-gram fitness, IOC, a composite with structural penalties) and a
+neighborhood move (swap two symbols of a key, conjugate a permutation), so
+one solver serves monoalphabetic keys, mixed alphabets, permutation gears,
+and anything else with a local move.
+
+Hill climbing finds local optima; the standard remedy is many independent
+starts, provided by `multi_start` with one deterministic seed per start.
+Before trusting a search that fails to find a key, run it on a planted
+instance: encrypt known plaintext with a known key and confirm the search
+recovers it — a search that cannot recover a planted key says nothing about
+a real ciphertext.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from aldegonde.exceptions import InvalidInputError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+S = TypeVar("S")
+
+Score = Callable[[S], float]
+"""A fitness function to maximize: state -> score."""
+
+Neighbor = Callable[[S, random.Random], S]
+"""A local move: (state, random source) -> nearby state."""
+
+
+@dataclass(frozen=True)
+class ClimbResult(Generic[S]):
+    """Outcome of a hill climb.
+
+    Attributes:
+        state: The best state found
+        score: Its score
+        proposals: Neighbor proposals evaluated
+        improvements: Proposals that improved the score
+    """
+
+    state: S
+    score: float
+    proposals: int
+    improvements: int
+
+
+def hill_climb(
+    initial: S,
+    neighbor: Neighbor[S],
+    score: Score[S],
+    *,
+    iterations: int = 10_000,
+    stagnation: int | None = None,
+    rng: random.Random,
+) -> ClimbResult[S]:
+    """Climb from an initial state, accepting strictly improving neighbors.
+
+    Proposes up to `iterations` neighbors, moving whenever the proposal
+    scores strictly higher. With `stagnation` set, the climb stops early
+    after that many consecutive non-improving proposals — the signal that a
+    local optimum is reached and further proposals are wasted; spend the
+    budget on another start instead.
+
+    Args:
+        initial: Starting state
+        neighbor: Local move proposing a nearby state
+        score: Fitness function to maximize
+        iterations: Maximum neighbor proposals
+        stagnation: Consecutive non-improving proposals before stopping;
+            None climbs the full budget
+        rng: Injected random source driving the neighborhood
+
+    Returns:
+        The best state found with its score and proposal counts
+
+    Raises:
+        InvalidInputError: If iterations or stagnation is not positive
+    """
+    if iterations < 1:
+        msg = f"iterations must be positive, got {iterations}"
+        raise InvalidInputError(msg)
+    if stagnation is not None and stagnation < 1:
+        msg = f"stagnation must be positive, got {stagnation}"
+        raise InvalidInputError(msg)
+    best = initial
+    best_score = score(initial)
+    proposals = 0
+    improvements = 0
+    since_improvement = 0
+    for _ in range(iterations):
+        proposals += 1
+        candidate = neighbor(best, rng)
+        candidate_score = score(candidate)
+        if candidate_score > best_score:
+            best = candidate
+            best_score = candidate_score
+            improvements += 1
+            since_improvement = 0
+        else:
+            since_improvement += 1
+            if stagnation is not None and since_improvement >= stagnation:
+                break
+    return ClimbResult(
+        state=best,
+        score=best_score,
+        proposals=proposals,
+        improvements=improvements,
+    )
+
+
+def multi_start(
+    initial_factory: Callable[[random.Random], S],
+    neighbor: Neighbor[S],
+    score: Score[S],
+    *,
+    starts: int = 10,
+    iterations: int = 10_000,
+    stagnation: int | None = None,
+    seed: int = 0,
+) -> tuple[ClimbResult[S], list[ClimbResult[S]]]:
+    """Run independent seeded climbs from fresh starts and keep the best.
+
+    Start i draws its initial state and its whole climb from
+    random.Random(seed + i), so a run is reproducible, any single start can
+    be replayed in isolation, and the starts are independent — the standard
+    answer to hill climbing's local optima.
+
+    Args:
+        initial_factory: Draws a fresh starting state from a random source
+        neighbor: Local move proposing a nearby state
+        score: Fitness function to maximize
+        starts: Number of independent climbs
+        iterations: Maximum proposals per climb
+        stagnation: Early-stop cutoff per climb; None climbs the full budget
+        seed: Base seed; start i uses random.Random(seed + i)
+
+    Returns:
+        The best climb result, and every start's result in start order
+
+    Raises:
+        InvalidInputError: If starts is not positive
+    """
+    if starts < 1:
+        msg = f"starts must be positive, got {starts}"
+        raise InvalidInputError(msg)
+    results: list[ClimbResult[S]] = []
+    for start in range(starts):
+        rng = random.Random(seed + start)
+        results.append(
+            hill_climb(
+                initial_factory(rng),
+                neighbor,
+                score,
+                iterations=iterations,
+                stagnation=stagnation,
+                rng=rng,
+            )
+        )
+    best = max(results, key=lambda result: result.score)
+    return best, results
+
+
+def swap_neighbor(state: Sequence[S], rng: random.Random) -> list[S]:
+    """Swap two distinct positions of a sequence state.
+
+    The canonical neighborhood for substitution keys and mixed alphabets:
+    every arrangement is reachable, and each move changes exactly two
+    images.
+
+    Args:
+        state: Sequence state, e.g. an alphabet arrangement
+        rng: Injected random source
+
+    Returns:
+        A new list with two positions exchanged
+
+    Raises:
+        InvalidInputError: If the state has fewer than 2 elements
+    """
+    if len(state) < 2:
+        msg = "swap_neighbor needs at least 2 elements"
+        raise InvalidInputError(msg)
+    out = list(state)
+    i, j = rng.sample(range(len(out)), 2)
+    out[i], out[j] = out[j], out[i]
+    return out
+
+
+def conjugation_neighbor(state: Sequence[int], rng: random.Random) -> list[int]:
+    """Conjugate a permutation state by a random transposition.
+
+    The cycle-type-preserving neighborhood: use it when the key is a
+    permutation whose cycle structure is part of the hypothesis (a gear of
+    known order) and only the labeling is unknown. See
+    `aldegonde.perm.transposition_conjugate`.
+
+    Args:
+        state: Permutation in index form
+        rng: Injected random source
+
+    Returns:
+        A conjugate permutation with the same cycle type
+    """
+    from aldegonde.perm import transposition_conjugate
+
+    a, b = rng.sample(range(len(state)), 2)
+    return transposition_conjugate(state, a, b)

--- a/src/aldegonde/sim/__init__.py
+++ b/src/aldegonde/sim/__init__.py
@@ -1,0 +1,15 @@
+"""Simulation utilities: language-like text generation for controls."""
+
+from aldegonde.sim.markov import (
+    MarkovModel,
+    cut_by_lengths,
+    fit_markov,
+    generate,
+)
+
+__all__ = [
+    "MarkovModel",
+    "cut_by_lengths",
+    "fit_markov",
+    "generate",
+]

--- a/src/aldegonde/sim/markov.py
+++ b/src/aldegonde/sim/markov.py
@@ -1,0 +1,209 @@
+# ABOUTME: Markov text generation from fitted or supplied n-gram counts, plus
+# ABOUTME: cutting a stream into words by an empirical length distribution.
+"""Language-like text generation for statistical controls.
+
+A simulation-based argument — "this cipher over natural language would
+produce these statistics" — needs a source of language-like plaintext. This
+module fits an order-k Markov model to an n-gram count table (or a training
+sequence) and samples fresh sequences from it, so a control corpus can be
+generated at any length over any alphabet. `cut_by_lengths` then segments a
+generated stream into words drawn from an empirical word-length
+distribution, reproducing the token structure the boundary-aware statistics
+need.
+
+This is generation, not a null model: use it to build a control corpus,
+then run the same analysis on it as on the real ciphertext. For a
+resampling null of an observed sequence, see `stats.nulls`.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from aldegonde.exceptions import InsufficientDataError, InvalidInputError
+
+if TYPE_CHECKING:
+    import random
+    from collections.abc import Mapping, Sequence
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+def _cumulative(weights: Mapping[U, float]) -> list[tuple[float, U]]:
+    """Turn a weight mapping into a cumulative distribution over its keys."""
+    total = sum(weights.values())
+    if total <= 0:
+        msg = "a Markov distribution has no positive weight"
+        raise InvalidInputError(msg)
+    cumulative: list[tuple[float, U]] = []
+    running = 0.0
+    for symbol, weight in weights.items():
+        running += weight / total
+        cumulative.append((running, symbol))
+    return cumulative
+
+
+def _draw(cumulative: list[tuple[float, U]], rng: random.Random) -> U:
+    """Draw one key from a cumulative distribution."""
+    target = rng.random()
+    for bound, symbol in cumulative:
+        if target < bound:
+            return symbol
+    return cumulative[-1][1]
+
+
+class MarkovModel(Generic[T]):
+    """An order-k Markov model over a fixed alphabet.
+
+    Holds, for each length-k context, a cumulative distribution over next
+    symbols, plus a distribution over starting contexts. Sampling is a pure
+    function of an injected random source.
+    """
+
+    def __init__(
+        self,
+        order: int,
+        alphabet: Sequence[T],
+        transitions: Mapping[tuple[T, ...], Mapping[T, float]],
+        starts: Mapping[tuple[T, ...], float],
+    ) -> None:
+        self.order = order
+        self.alphabet = list(alphabet)
+        self._rows = {
+            context: _cumulative(weights) for context, weights in transitions.items()
+        }
+        self._start_cumulative = _cumulative(starts)
+
+    def sample(self, length: int, rng: random.Random) -> list[T]:
+        """Sample a sequence of the given length from the model.
+
+        Args:
+            length: Number of symbols to generate
+            rng: Injected random source
+
+        Returns:
+            A generated sequence of alphabet symbols
+
+        Raises:
+            InvalidInputError: If length is negative
+        """
+        if length < 0:
+            msg = f"length must be non-negative, got {length}"
+            raise InvalidInputError(msg)
+        if length == 0:
+            return []
+        context: tuple[T, ...] = _draw(self._start_cumulative, rng)
+        out = list(context[:length])
+        while len(out) < length:
+            row = self._rows.get(context)
+            if row is None:
+                # unseen context: restart from a random starting context
+                context = _draw(self._start_cumulative, rng)
+                out.extend(context[: length - len(out)])
+                continue
+            nxt = _draw(row, rng)
+            out.append(nxt)
+            context = (*context[1:], nxt)
+        return out[:length]
+
+
+def fit_markov(
+    training: Sequence[T],
+    order: int,
+    alphabet: Sequence[T] | None = None,
+    smoothing: float = 0.0,
+) -> MarkovModel[T]:
+    """Fit an order-k Markov model to a training sequence.
+
+    Args:
+        training: Sequence to learn transition counts from
+        order: Context length k (order 1 is a bigram model)
+        alphabet: Alphabet to smooth over; the symbols seen when omitted
+        smoothing: Add-`smoothing` pseudo-count for every next symbol,
+            keeping unseen transitions possible
+
+    Returns:
+        A fitted MarkovModel
+
+    Raises:
+        InvalidInputError: If order is not positive or smoothing is negative
+        InsufficientDataError: If the training sequence is shorter than the
+            order plus one
+    """
+    if order < 1:
+        msg = f"order must be positive, got {order}"
+        raise InvalidInputError(msg)
+    if smoothing < 0:
+        msg = f"smoothing must be non-negative, got {smoothing}"
+        raise InvalidInputError(msg)
+    if len(training) < order + 1:
+        msg = f"need more than {order} symbols to fit an order-{order} model"
+        raise InsufficientDataError(msg, order + 1, len(training))
+    symbols = (
+        list(alphabet)
+        if alphabet is not None
+        else list(dict.fromkeys(training))  # stable unique, no ordering needed
+    )
+    transitions: dict[tuple[T, ...], Counter[T]] = {}
+    starts: Counter[tuple[T, ...]] = Counter()
+    for i in range(len(training) - order):
+        context = tuple(training[i : i + order])
+        nxt = training[i + order]
+        transitions.setdefault(context, Counter())[nxt] += 1
+        starts[context] += 1
+    weighted: dict[tuple[T, ...], dict[T, float]] = {}
+    for context, counts in transitions.items():
+        weighted[context] = {
+            symbol: counts.get(symbol, 0) + smoothing for symbol in symbols
+        }
+    return MarkovModel(order, symbols, weighted, dict(starts))
+
+
+def generate(model: MarkovModel[T], length: int, rng: random.Random) -> list[T]:
+    """Sample a sequence of the given length from a fitted model."""
+    return model.sample(length, rng)
+
+
+def cut_by_lengths(
+    stream: Sequence[T],
+    length_distribution: Mapping[int, float],
+    rng: random.Random,
+) -> list[list[T]]:
+    """Cut a stream into words drawn from an empirical length distribution.
+
+    Word lengths are sampled from the given distribution until the stream is
+    consumed; the final word is whatever remains, so no symbols are lost.
+
+    Args:
+        stream: Symbol stream to segment
+        length_distribution: Mapping from word length to relative weight
+        rng: Injected random source
+
+    Returns:
+        The stream cut into words
+
+    Raises:
+        InvalidInputError: If the distribution is empty, has a non-positive
+            length, or has no positive weight
+    """
+    if not length_distribution:
+        msg = "length_distribution must not be empty"
+        raise InvalidInputError(msg)
+    lengths = list(length_distribution)
+    weights = [length_distribution[length] for length in lengths]
+    if any(length < 1 for length in lengths):
+        msg = "word lengths must be positive"
+        raise InvalidInputError(msg)
+    if sum(weights) <= 0:
+        msg = "length_distribution has no positive weight"
+        raise InvalidInputError(msg)
+    words: list[list[T]] = []
+    position = 0
+    n = len(stream)
+    while position < n:
+        length = rng.choices(lengths, weights=weights, k=1)[0]
+        words.append(list(stream[position : position + length]))
+        position += length
+    return words

--- a/src/aldegonde/stats/__init__.py
+++ b/src/aldegonde/stats/__init__.py
@@ -1,5 +1,11 @@
 """Statistical analysis tools for cryptanalysis."""
 
+from aldegonde.stats.binomial import (
+    WilsonInterval,
+    coincidence_z,
+    two_proportion_z,
+    wilson_interval,
+)
 from aldegonde.stats.chisq import (
     ChiSquare,
     goodness_of_fit,
@@ -99,6 +105,11 @@ from aldegonde.stats.resample import (
 from aldegonde.stats.zscore import z_score
 
 __all__ = [
+    # binomial
+    "WilsonInterval",
+    "coincidence_z",
+    "two_proportion_z",
+    "wilson_interval",
     # chisq
     "ChiSquare",
     "goodness_of_fit",

--- a/src/aldegonde/stats/__init__.py
+++ b/src/aldegonde/stats/__init__.py
@@ -1,5 +1,13 @@
 """Statistical analysis tools for cryptanalysis."""
 
+from aldegonde.stats.chisq import (
+    ChiSquare,
+    goodness_of_fit,
+    lag_contingency,
+    rate_uniformity,
+    uniformity,
+    wilson_hilferty,
+)
 from aldegonde.stats.compare import (
     NgramScorer,
     bigramscore,
@@ -33,8 +41,24 @@ from aldegonde.stats.isomorph import (
     print_isomorph_statistics,
     random_isomorph_statistics,
 )
-from aldegonde.stats.kappa import doublets, kappa, print_kappa, triplets
+from aldegonde.stats.kappa import (
+    KappaZ,
+    doublets,
+    kappa,
+    kappa_spectrum,
+    print_kappa,
+    triplets,
+)
 from aldegonde.stats.mioc import MiocTuple, mioc, nmioc, print_mioc_statistics
+from aldegonde.stats.multitest import (
+    MultiplicityBudget,
+    bonferroni,
+    bonferroni_threshold,
+    expected_max_z,
+    multiplicity_budget,
+    sidak,
+    sidak_threshold,
+)
 from aldegonde.stats.ngrams import (
     bigrams,
     digraphs,
@@ -50,7 +74,10 @@ from aldegonde.stats.ngrams import (
 )
 from aldegonde.stats.nulls import (
     NullModel,
+    doublet_markov,
     doublet_shuffle,
+    fitted_markov,
+    markov_model,
     no_doublet_shuffle,
     shuffle,
 )
@@ -72,6 +99,13 @@ from aldegonde.stats.resample import (
 from aldegonde.stats.zscore import z_score
 
 __all__ = [
+    # chisq
+    "ChiSquare",
+    "goodness_of_fit",
+    "lag_contingency",
+    "rate_uniformity",
+    "uniformity",
+    "wilson_hilferty",
     # compare
     "NgramScorer",
     "bigramscore",
@@ -107,8 +141,10 @@ __all__ = [
     "print_isomorph_statistics",
     "random_isomorph_statistics",
     # kappa
+    "KappaZ",
     "doublets",
     "kappa",
+    "kappa_spectrum",
     "print_kappa",
     "triplets",
     # mioc
@@ -116,6 +152,14 @@ __all__ = [
     "mioc",
     "nmioc",
     "print_mioc_statistics",
+    # multitest
+    "MultiplicityBudget",
+    "bonferroni",
+    "bonferroni_threshold",
+    "expected_max_z",
+    "multiplicity_budget",
+    "sidak",
+    "sidak_threshold",
     # ngrams
     "bigrams",
     "digraphs",
@@ -130,7 +174,10 @@ __all__ = [
     "trigraphs",
     # nulls
     "NullModel",
+    "doublet_markov",
     "doublet_shuffle",
+    "fitted_markov",
+    "markov_model",
     "no_doublet_shuffle",
     "shuffle",
     # position

--- a/src/aldegonde/stats/binomial.py
+++ b/src/aldegonde/stats/binomial.py
@@ -1,0 +1,164 @@
+# ABOUTME: Binomial helpers used across coincidence tests: coincidence z,
+# ABOUTME: the Wilson score interval, and the two-proportion z test.
+"""Binomial inference for coincidence and rate comparisons.
+
+Small, exact helpers that recur throughout coincidence analysis and are
+easy to get subtly wrong when re-derived inline:
+
+`coincidence_z` standardizes a count of matches among a number of
+opportunities against the chance rate 1/alphabetsize — the binomial z
+behind kappa, boundary coincidence, and alignment tests.
+
+`wilson_interval` is the Wilson score confidence interval for a proportion,
+which behaves well for small counts and rates near 0 or 1 where the normal
+approximation fails, and needs no special-casing of zero counts.
+
+`two_proportion_z` tests whether two rates differ, pooling their counts
+under the null — the standard "does this effect respect the boundary"
+comparison of a within-group rate against an across-group rate.
+"""
+
+from __future__ import annotations
+
+from math import sqrt
+from typing import NamedTuple
+
+from aldegonde.exceptions import InvalidInputError
+
+
+def coincidence_z(hits: int, opportunities: int, alphabetsize: int) -> float:
+    """Standardize a coincidence count against the chance rate 1/alphabetsize.
+
+    Treats each of `opportunities` comparisons as a Bernoulli trial with
+    success probability 1/alphabetsize and returns the standard score of the
+    observed `hits`. Positive means more coincidences than chance.
+
+    Args:
+        hits: Observed matching comparisons
+        opportunities: Total comparisons made
+        alphabetsize: Alphabet size fixing the chance rate
+
+    Returns:
+        The binomial standard score, 0.0 when no opportunities
+
+    Raises:
+        InvalidInputError: If alphabetsize < 2, counts are negative, or hits
+            exceed opportunities
+    """
+    if alphabetsize < 2:
+        msg = f"alphabetsize must be at least 2, got {alphabetsize}"
+        raise InvalidInputError(msg)
+    if hits < 0 or opportunities < 0:
+        msg = "hits and opportunities must be non-negative"
+        raise InvalidInputError(msg)
+    if hits > opportunities:
+        msg = f"hits {hits} exceed opportunities {opportunities}"
+        raise InvalidInputError(msg)
+    if opportunities == 0:
+        return 0.0
+    rate = 1.0 / alphabetsize
+    expected = opportunities * rate
+    sd = sqrt(opportunities * rate * (1.0 - rate))
+    return (hits - expected) / sd if sd > 0 else 0.0
+
+
+class WilsonInterval(NamedTuple):
+    """A Wilson score interval for a proportion.
+
+    Attributes:
+        estimate: The observed proportion hits / trials
+        low: Lower confidence bound
+        high: Upper confidence bound
+    """
+
+    estimate: float
+    low: float
+    high: float
+
+
+def wilson_interval(
+    hits: int,
+    trials: int,
+    z: float = 1.959963984540054,
+) -> WilsonInterval:
+    """Return the Wilson score confidence interval for a proportion.
+
+    Well-behaved for small samples and for rates near 0 or 1, where the
+    normal-approximation interval can leave [0, 1] or collapse to zero
+    width; requires no dependency beyond the standard library.
+
+    Args:
+        hits: Observed successes
+        trials: Total trials
+        z: Standard-normal quantile for the confidence level; the default is
+            the two-sided 95% value
+
+    Returns:
+        The point estimate and the lower and upper bounds
+
+    Raises:
+        InvalidInputError: If trials < 1, hits is out of range, or z is
+            negative
+    """
+    if trials < 1:
+        msg = f"trials must be at least 1, got {trials}"
+        raise InvalidInputError(msg)
+    if not 0 <= hits <= trials:
+        msg = f"hits {hits} out of range for {trials} trials"
+        raise InvalidInputError(msg)
+    if z < 0:
+        msg = f"z must be non-negative, got {z}"
+        raise InvalidInputError(msg)
+    phat = hits / trials
+    denominator = 1.0 + z * z / trials
+    center = (phat + z * z / (2 * trials)) / denominator
+    half = (
+        z
+        * sqrt(phat * (1.0 - phat) / trials + z * z / (4 * trials * trials))
+        / denominator
+    )
+    return WilsonInterval(
+        estimate=phat,
+        low=max(0.0, center - half),
+        high=min(1.0, center + half),
+    )
+
+
+def two_proportion_z(
+    hits1: int,
+    trials1: int,
+    hits2: int,
+    trials2: int,
+) -> float:
+    """Test whether two proportions differ, pooling counts under the null.
+
+    Returns the standard score of the difference in rates, using the pooled
+    rate for the standard error as the null hypothesis of equal rates
+    requires. The classic use is a within-group rate against an across-group
+    rate: a large z means the effect does not respect the grouping.
+
+    Args:
+        hits1: Successes in the first group
+        trials1: Trials in the first group
+        hits2: Successes in the second group
+        trials2: Trials in the second group
+
+    Returns:
+        The two-proportion standard score; positive means group 1's rate is
+        higher
+
+    Raises:
+        InvalidInputError: If a group has no trials, or a hit count is out of
+            range
+    """
+    if trials1 < 1 or trials2 < 1:
+        msg = "both groups need at least one trial"
+        raise InvalidInputError(msg)
+    if not (0 <= hits1 <= trials1 and 0 <= hits2 <= trials2):
+        msg = "hit counts must lie within their trial counts"
+        raise InvalidInputError(msg)
+    rate1 = hits1 / trials1
+    rate2 = hits2 / trials2
+    pooled = (hits1 + hits2) / (trials1 + trials2)
+    se = sqrt(pooled * (1.0 - pooled) * (1.0 / trials1 + 1.0 / trials2))
+    return (rate1 - rate2) / se if se > 0 else 0.0

--- a/src/aldegonde/stats/chisq.py
+++ b/src/aldegonde/stats/chisq.py
@@ -1,0 +1,289 @@
+# ABOUTME: Chi-square tests packaged with a z effect size: uniformity,
+# ABOUTME: exposure-weighted rate uniformity, and lag contingency tables.
+"""Chi-square tests with a standardized effect size.
+
+Every test returns a ChiSquare carrying the statistic, its degrees of
+freedom, the Wilson-Hilferty z (a normal-scale effect size comparable across
+tests with different df), and the survival p-value. The z answers "how far
+from null", the p answers "how surprising"; when a test is one of many in a
+scan, correct the p with `stats.multitest` before believing it.
+
+Tests included:
+
+    uniformity            symbol counts against a flat distribution
+    goodness_of_fit       counts against arbitrary expected weights
+    rate_uniformity       event rates across bins with unequal exposure
+    lag_contingency       (x[i], x[i+lag]) table against independence,
+                          optionally masking the diagonal
+"""
+
+from __future__ import annotations
+
+from math import sqrt
+from typing import TYPE_CHECKING, NamedTuple, TypeVar
+
+from scipy.stats import chi2 as _chi2_dist
+
+from aldegonde.exceptions import InsufficientDataError, InvalidInputError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+T = TypeVar("T")
+K = TypeVar("K")
+
+
+class ChiSquare(NamedTuple):
+    """A chi-square statistic with its normal-scale effect size.
+
+    Attributes:
+        chi2: The chi-square statistic
+        df: Degrees of freedom
+        z: Wilson-Hilferty standardized value; positive means more structure
+            than the null expects
+        p: Survival probability of chi2 at df degrees of freedom
+    """
+
+    chi2: float
+    df: int
+    z: float
+    p: float
+
+
+def wilson_hilferty(chi2: float, df: int) -> float:
+    """Map a chi-square value to an approximate standard normal z.
+
+    The Wilson-Hilferty cube-root transform: the z is comparable across
+    tests with different degrees of freedom, which raw chi-square values are
+    not.
+
+    Args:
+        chi2: The chi-square statistic
+        df: Degrees of freedom
+
+    Returns:
+        The approximate standard normal deviate
+
+    Raises:
+        InvalidInputError: If df < 1 or chi2 is negative
+    """
+    if df < 1:
+        msg = f"degrees of freedom must be at least 1, got {df}"
+        raise InvalidInputError(msg)
+    if chi2 < 0:
+        msg = f"chi-square must be non-negative, got {chi2}"
+        raise InvalidInputError(msg)
+    variance = 2.0 / (9.0 * df)
+    cube_root = float((chi2 / df) ** (1.0 / 3.0))
+    return (cube_root - (1.0 - variance)) / sqrt(variance)
+
+
+def _package(chi2: float, df: int) -> ChiSquare:
+    return ChiSquare(
+        chi2=chi2,
+        df=df,
+        z=wilson_hilferty(chi2, df),
+        p=float(_chi2_dist.sf(chi2, df)),
+    )
+
+
+def uniformity(counts: Sequence[int]) -> ChiSquare:
+    """Test whether counts over categories are uniform.
+
+    Args:
+        counts: Observed count per category, including zero-count categories
+
+    Returns:
+        The chi-square against the flat expectation, df = categories - 1
+
+    Raises:
+        InsufficientDataError: If there are fewer than 2 categories or no
+            observations
+    """
+    if len(counts) < 2:
+        msg = "uniformity needs at least 2 categories"
+        raise InsufficientDataError(msg, 2, len(counts))
+    total = sum(counts)
+    if total == 0:
+        msg = "uniformity needs at least one observation"
+        raise InsufficientDataError(msg, 1, 0)
+    expected = total / len(counts)
+    statistic = sum((count - expected) ** 2 / expected for count in counts)
+    return _package(statistic, len(counts) - 1)
+
+
+def goodness_of_fit(counts: Sequence[int], weights: Sequence[float]) -> ChiSquare:
+    """Test counts against expected weights.
+
+    The weights need not sum to anything in particular; they are scaled to
+    the observed total. Categories with zero weight must have zero count.
+
+    Args:
+        counts: Observed count per category
+        weights: Expected relative weight per category
+
+    Returns:
+        The chi-square against the scaled weights, df = categories - 1
+
+    Raises:
+        InvalidInputError: If lengths differ, a weight is negative, or a
+            zero-weight category has observations
+        InsufficientDataError: If there are fewer than 2 categories or no
+            observations
+    """
+    if len(counts) != len(weights):
+        msg = f"{len(counts)} counts but {len(weights)} weights"
+        raise InvalidInputError(msg)
+    if len(counts) < 2:
+        msg = "goodness_of_fit needs at least 2 categories"
+        raise InsufficientDataError(msg, 2, len(counts))
+    if any(weight < 0 for weight in weights):
+        msg = "weights must be non-negative"
+        raise InvalidInputError(msg)
+    total = sum(counts)
+    weight_total = sum(weights)
+    if total == 0 or weight_total == 0:
+        msg = "goodness_of_fit needs observations and positive total weight"
+        raise InsufficientDataError(msg, 1, 0)
+    statistic = 0.0
+    for count, weight in zip(counts, weights):
+        expected = total * weight / weight_total
+        if expected == 0:
+            if count:
+                msg = "a zero-weight category has observations"
+                raise InvalidInputError(msg)
+            continue
+        statistic += (count - expected) ** 2 / expected
+    return _package(statistic, len(counts) - 1)
+
+
+def rate_uniformity(bins: Mapping[K, tuple[int, int]]) -> ChiSquare:
+    """Test whether an event rate is uniform across bins with unequal exposure.
+
+    Each bin carries (exposure, events): the number of opportunities the bin
+    offered and the number of events that occurred there. The null is one
+    shared rate — total events over total exposure — so a significant result
+    means the rate itself depends on the bin, not merely that big bins hold
+    more events. This is the correct form of "do events cluster on axis X"
+    whenever bins differ in size; a plain frequency chi-square is not.
+
+    Args:
+        bins: Mapping from bin label to (exposure, events)
+
+    Returns:
+        The chi-square of events against the shared-rate expectation over
+        bins with positive exposure, df = such bins - 1
+
+    Raises:
+        InvalidInputError: If a bin has negative exposure or events, or
+            events exceed exposure
+        InsufficientDataError: If fewer than 2 bins have exposure, or no
+            events occurred anywhere
+    """
+    exposed: list[tuple[int, int]] = []
+    for label, (exposure, events) in bins.items():
+        if exposure < 0 or events < 0 or events > exposure:
+            msg = (
+                f"bin {label!r} has invalid (exposure, events) = ({exposure}, {events})"
+            )
+            raise InvalidInputError(msg)
+        if exposure > 0:
+            exposed.append((exposure, events))
+    if len(exposed) < 2:
+        msg = "rate_uniformity needs at least 2 bins with exposure"
+        raise InsufficientDataError(msg, 2, len(exposed))
+    total_exposure = sum(exposure for exposure, _ in exposed)
+    total_events = sum(events for _, events in exposed)
+    if total_events == 0:
+        msg = "rate_uniformity needs at least one event"
+        raise InsufficientDataError(msg, 1, 0)
+    rate = total_events / total_exposure
+    statistic = sum(
+        (events - rate * exposure) ** 2 / (rate * exposure)
+        for exposure, events in exposed
+    )
+    return _package(statistic, len(exposed) - 1)
+
+
+def lag_contingency(
+    text: Sequence[T],
+    lag: int,
+    *,
+    off_diagonal: bool = False,
+) -> ChiSquare:
+    """Test the pairs (x[i], x[i+lag]) against independence.
+
+    The omnibus second-order dependence test: it sees any relation between a
+    symbol and the symbol lag positions later, not only equality, which is
+    all the kappa test measures. With off_diagonal=True the diagonal cells
+    are removed and the remaining expectations are renormalized to the
+    off-diagonal mass, so a pure doublet suppression or enhancement scores
+    zero and only structure beyond it registers. The masked form is a quasi
+    chi-square with df = (n-1)^2 - n — indicative, best confirmed against a
+    resampled null.
+
+    Args:
+        text: Sequence to analyze
+        lag: Distance between the paired symbols
+        off_diagonal: Exclude cells where both symbols are equal
+
+    Returns:
+        The chi-square of the pair table against the product of its
+        marginals
+
+    Raises:
+        InvalidInputError: If lag is not positive
+        InsufficientDataError: If the text offers no pairs at this lag or
+            uses fewer than 2 distinct symbols
+    """
+    if lag < 1:
+        msg = f"lag must be positive, got {lag}"
+        raise InvalidInputError(msg)
+    pairs = len(text) - lag
+    if pairs < 1:
+        msg = f"text of length {len(text)} has no pairs at lag {lag}"
+        raise InsufficientDataError(msg, lag + 1, len(text))
+    symbols: list[T] = []
+    index: dict[T, int] = {}
+    for symbol in text:
+        if symbol not in index:
+            index[symbol] = len(symbols)
+            symbols.append(symbol)
+    n = len(symbols)
+    if n < 2:
+        msg = "lag_contingency needs at least 2 distinct symbols"
+        raise InsufficientDataError(msg, 2, n)
+    table = [[0] * n for _ in range(n)]
+    row_totals = [0] * n
+    column_totals = [0] * n
+    for i in range(pairs):
+        row = index[text[i]]
+        column = index[text[i + lag]]
+        table[row][column] += 1
+        row_totals[row] += 1
+        column_totals[column] += 1
+    scale = 1.0
+    if off_diagonal:
+        # Renormalize the independence expectations to the off-diagonal mass,
+        # so removing the diagonal does not misstate every remaining cell
+        observed_mass = pairs - sum(table[i][i] for i in range(n))
+        expected_mass = pairs - sum(
+            row_totals[i] * column_totals[i] / pairs for i in range(n)
+        )
+        if observed_mass == 0 or expected_mass == 0:
+            msg = "masking the diagonal leaves no off-diagonal mass"
+            raise InsufficientDataError(msg, 1, 0)
+        scale = observed_mass / expected_mass
+    statistic = 0.0
+    for row in range(n):
+        for column in range(n):
+            if off_diagonal and row == column:
+                continue
+            expected = scale * row_totals[row] * column_totals[column] / pairs
+            if expected > 0:
+                statistic += (table[row][column] - expected) ** 2 / expected
+    df = (n - 1) * (n - 1) - (n if off_diagonal else 0)
+    if df < 1:
+        msg = "masking the diagonal leaves no degrees of freedom"
+        raise InsufficientDataError(msg, 1, df)
+    return _package(statistic, df)

--- a/src/aldegonde/stats/kappa.py
+++ b/src/aldegonde/stats/kappa.py
@@ -5,15 +5,84 @@ which can reveal periodic patterns in ciphertext. Multigraphic kappa extends thi
 to detect repeated digraphs, trigraphs, etc.
 """
 
+from collections import Counter
 from collections.abc import Sequence
 from math import sqrt
-from typing import TypeVar
+from typing import NamedTuple, TypeVar
 
+from aldegonde.exceptions import InsufficientDataError
 from aldegonde.stats.nulls import NullModel
 from aldegonde.stats.resample import monte_carlo_map
 from aldegonde.stats.zscore import z_score
 
 T = TypeVar("T")
+
+
+class KappaZ(NamedTuple):
+    """A doublet count at one skip, standardized against the frequency null.
+
+    Attributes:
+        observed: Observed doublets at this skip
+        comparisons: Positions compared at this skip
+        expected: Count expected under the frequency-matched chance rate
+        z: Binomial standard score of the count against that expectation
+    """
+
+    observed: int
+    comparisons: int
+    expected: float
+    z: float
+
+
+def kappa_spectrum(
+    text: Sequence[object],
+    skips: Sequence[int],
+    length: int = 1,
+) -> dict[int, KappaZ]:
+    """Standardized doublet counts at every skip, against the frequency null.
+
+    The chance coincidence rate is taken from the observed symbol
+    frequencies (the sum of squared frequencies, raised to the n-gram
+    length), not from 1/alphabetsize — the correct null for a non-flat
+    alphabet, which the uniform rate systematically misjudges. Each skip's
+    count is standardized as a binomial z against that rate.
+
+    The skips form a scan: read the spectrum with `stats.multitest`
+    (expected_max_z, multiplicity_budget) or confirm a peak with
+    `stats.resample.family_pvalue` rather than trusting any single z.
+
+    Args:
+        text: Sequence to analyze
+        skips: Skip distances to evaluate
+        length: Size of compared n-grams (1 = monographic)
+
+    Returns:
+        A KappaZ per skip that admits at least one comparison
+
+    Raises:
+        InsufficientDataError: If the text is empty
+    """
+    if len(text) == 0:
+        msg = "kappa_spectrum needs a non-empty sequence"
+        raise InsufficientDataError(msg, 1, 0)
+    frequencies = Counter(text)
+    n = len(text)
+    rate = sum((count / n) ** 2 for count in frequencies.values()) ** length
+    spectrum: dict[int, KappaZ] = {}
+    for skip in skips:
+        comparisons = n - skip - length + 1
+        if comparisons < 1:
+            continue
+        count = doublet_count(text, skip=skip, length=length)
+        expected = comparisons * rate
+        sd = sqrt(comparisons * rate * (1.0 - rate))
+        spectrum[skip] = KappaZ(
+            observed=count,
+            comparisons=comparisons,
+            expected=expected,
+            z=z_score(count, expected, sd),
+        )
+    return spectrum
 
 
 def doublets(

--- a/src/aldegonde/stats/multitest.py
+++ b/src/aldegonde/stats/multitest.py
@@ -1,0 +1,189 @@
+# ABOUTME: Multiple-comparison corrections for scan statistics: Bonferroni,
+# ABOUTME: Sidak, the expected-max z threshold, and the multiplicity budget.
+"""Multiple-testing corrections for scans over lags, periods, and offsets.
+
+Any statistic scanned over a family of keys (every lag, every period, every
+offset) will produce impressive-looking extremes by chance alone; the
+corrections here price that look-elsewhere effect analytically. They are the
+cheap complement to the empirical route in `stats.resample.family_pvalue`,
+which resamples the maximum itself: use Bonferroni or Sidak when the per-test
+null is known and trials are expensive, and the resampled family-wise p-value
+when it is not.
+
+The expected-max threshold and the multiplicity budget are coarser
+instruments for reading a whole z-spectrum at once: the largest of n
+independent standard normals sits near sqrt(2 ln n), so a spectrum whose peak
+merely reaches that level is unremarkable, and a spectrum with more
+|z| >= t entries than the budget predicts is structured even if no single
+entry survives correction.
+"""
+
+from __future__ import annotations
+
+from math import erfc, log, sqrt
+from typing import TYPE_CHECKING, NamedTuple
+
+from aldegonde.exceptions import InvalidInputError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def _validate_tests(tests: int) -> None:
+    if tests < 1:
+        msg = f"number of tests must be at least 1, got {tests}"
+        raise InvalidInputError(msg)
+
+
+def _validate_probability(value: float, name: str) -> None:
+    if not 0.0 <= value <= 1.0:
+        msg = f"{name} must be in [0, 1], got {value}"
+        raise InvalidInputError(msg)
+
+
+def bonferroni(p_value: float, tests: int) -> float:
+    """Return the Bonferroni-corrected p-value, capped at 1.
+
+    Args:
+        p_value: Uncorrected per-test p-value
+        tests: Number of tests in the family
+
+    Returns:
+        min(1, p_value * tests)
+
+    Raises:
+        InvalidInputError: If p_value is outside [0, 1] or tests < 1
+    """
+    _validate_probability(p_value, "p_value")
+    _validate_tests(tests)
+    return min(1.0, p_value * tests)
+
+
+def sidak(p_value: float, tests: int) -> float:
+    """Return the Sidak-corrected p-value.
+
+    Exact for independent tests and slightly less conservative than
+    Bonferroni; for correlated tests it is approximate.
+
+    Args:
+        p_value: Uncorrected per-test p-value
+        tests: Number of tests in the family
+
+    Returns:
+        1 - (1 - p_value) ** tests
+
+    Raises:
+        InvalidInputError: If p_value is outside [0, 1] or tests < 1
+    """
+    _validate_probability(p_value, "p_value")
+    _validate_tests(tests)
+    return 1.0 - (1.0 - p_value) ** tests
+
+
+def bonferroni_threshold(alpha: float, tests: int) -> float:
+    """Return the per-test alpha giving family-wise level alpha under Bonferroni.
+
+    Args:
+        alpha: Desired family-wise significance level
+        tests: Number of tests in the family
+
+    Returns:
+        alpha / tests
+
+    Raises:
+        InvalidInputError: If alpha is outside [0, 1] or tests < 1
+    """
+    _validate_probability(alpha, "alpha")
+    _validate_tests(tests)
+    return alpha / tests
+
+
+def sidak_threshold(alpha: float, tests: int) -> float:
+    """Return the per-test alpha giving family-wise level alpha under Sidak.
+
+    Args:
+        alpha: Desired family-wise significance level
+        tests: Number of tests in the family
+
+    Returns:
+        1 - (1 - alpha) ** (1 / tests)
+
+    Raises:
+        InvalidInputError: If alpha is outside [0, 1] or tests < 1
+    """
+    _validate_probability(alpha, "alpha")
+    _validate_tests(tests)
+    return 1.0 - float((1.0 - alpha) ** (1.0 / tests))
+
+
+def expected_max_z(tests: int) -> float:
+    """Return the expected peak of n independent standard normal draws.
+
+    The maximum of n independent |z| values concentrates near sqrt(2 ln n).
+    A scan whose best peak merely reaches this level has found nothing; a
+    peak well above it deserves a proper corrected p-value.
+
+    Args:
+        tests: Number of tests in the family
+
+    Returns:
+        sqrt(2 * ln(tests)), or 0.0 for a single test
+
+    Raises:
+        InvalidInputError: If tests < 1
+    """
+    _validate_tests(tests)
+    return sqrt(2.0 * log(tests))
+
+
+class MultiplicityBudget(NamedTuple):
+    """Observed versus expected count of extreme z-scores in a spectrum.
+
+    Attributes:
+        observed: How many z-scores meet the threshold
+        expected: How many would meet it by chance under the standard normal
+        tests: Number of z-scores examined
+    """
+
+    observed: int
+    expected: float
+    tests: int
+
+
+def multiplicity_budget(
+    zscores: Iterable[float],
+    threshold: float,
+    *,
+    two_sided: bool = True,
+) -> MultiplicityBudget:
+    """Count z-scores past a threshold against the chance expectation.
+
+    Reads a whole z-spectrum at once: even when no single entry survives
+    correction, an observed count well above the expected one means the
+    spectrum as a whole is structured. Under a skewed or correlated null the
+    expectation is only indicative.
+
+    Args:
+        zscores: The z-scores of the scan
+        threshold: The cut at which a z-score counts as extreme
+        two_sided: Count |z| >= threshold; if False, count z >= threshold
+
+    Returns:
+        The observed count, the expected count under the standard normal,
+        and the number of tests
+
+    Raises:
+        InvalidInputError: If threshold is negative
+    """
+    if threshold < 0:
+        msg = f"threshold must be non-negative, got {threshold}"
+        raise InvalidInputError(msg)
+    values = list(zscores)
+    tail = erfc(threshold / sqrt(2.0))
+    per_test = tail if two_sided else tail / 2.0
+    observed = sum(1 for z in values if (abs(z) if two_sided else z) >= threshold)
+    return MultiplicityBudget(
+        observed=observed,
+        expected=per_test * len(values),
+        tests=len(values),
+    )

--- a/src/aldegonde/stats/nulls.py
+++ b/src/aldegonde/stats/nulls.py
@@ -9,11 +9,21 @@ randomizes everything else. Comparing an observed statistic against the
 distribution of the same statistic over many surrogates isolates the
 structure the null does not contain.
 
-The nulls implemented here both preserve the exact multiset of symbols:
+Two families are implemented. The shuffle family preserves the exact
+multiset of symbols of the observed sequence:
 
     shuffle             exact unigram frequencies, order destroyed
     no_doublet_shuffle  exact frequencies and no adjacent equal symbols
     doublet_shuffle     exact frequencies at a chosen adjacent-doublet rate
+
+The generative family draws fresh symbols from a first-order Markov chain,
+matching the observed sequence only in length. This is the standard
+surrogate-data construction for "my corpus has a known bigram-level nuisance
+property; the null must carry it or every downstream scan lies":
+
+    markov_model        surrogates from an explicit transition matrix
+    fitted_markov       transitions fitted to the observed sequence
+    doublet_markov      uniform marginals with a pinned self-transition rate
 
 Randomness is injected as a random.Random so a seeded run is reproducible and
 trials are independent; the resampler is a pure function of (data, rng).
@@ -159,3 +169,185 @@ def _doublet_fill(data: Sequence[T], rng: random.Random, factor: float) -> list[
         remaining[chosen] -= 1
         previous = chosen
     return out
+
+
+def _cumulative_rows(
+    alphabet: Sequence[T],
+    transitions: dict[T, list[float]],
+) -> dict[T, list[float]]:
+    """Normalize each transition row into a cumulative distribution."""
+    rows: dict[T, list[float]] = {}
+    for symbol, weights in transitions.items():
+        total = sum(weights)
+        if total <= 0:
+            msg = f"transition row for {symbol!r} has no positive weight"
+            raise InvalidInputError(msg)
+        cumulative: list[float] = []
+        running = 0.0
+        for weight in weights:
+            if weight < 0:
+                msg = f"negative transition weight in row for {symbol!r}"
+                raise InvalidInputError(msg)
+            running += weight / total
+            cumulative.append(running)
+        cumulative[-1] = 1.0
+        rows[symbol] = cumulative
+    return rows
+
+
+def _draw(alphabet: Sequence[T], cumulative: list[float], rng: random.Random) -> T:
+    """Draw one symbol from a cumulative distribution over the alphabet."""
+    target = rng.random()
+    for i, bound in enumerate(cumulative):
+        if target < bound:
+            return alphabet[i]
+    return alphabet[-1]
+
+
+def _generate_chain(
+    alphabet: Sequence[T],
+    rows: dict[T, list[float]],
+    initial: list[float],
+    length: int,
+    rng: random.Random,
+) -> list[T]:
+    """Generate a sequence from a first-order chain in cumulative form."""
+    out: list[T] = []
+    if length == 0:
+        return out
+    previous = _draw(alphabet, initial, rng)
+    out.append(previous)
+    for _ in range(length - 1):
+        previous = _draw(alphabet, rows[previous], rng)
+        out.append(previous)
+    return out
+
+
+def markov_model(
+    alphabet: Sequence[T],
+    transitions: dict[T, Sequence[float]],
+    initial: Sequence[float] | None = None,
+) -> NullModel[T]:
+    """Build a generative null from an explicit first-order Markov chain.
+
+    Surrogates are drawn fresh from the chain and match the observed sequence
+    only in length — unlike the shuffle family, the symbol multiset is not
+    preserved. Use this when the null hypothesis is a *process* ("text whose
+    only structure is these transition rates") rather than a rearrangement of
+    the observed symbols.
+
+    Args:
+        alphabet: The alphabet; row weights are indexed in this order
+        transitions: Weight row per symbol; each row is normalized, so any
+            positive scale works
+        initial: Weights for the first symbol; uniform when omitted
+
+    Returns:
+        A null model generating length-matched surrogates from the chain
+
+    Raises:
+        InvalidInputError: If the alphabet is empty, a row is missing or the
+            wrong size, or any weight is negative or a row sums to zero
+    """
+    if not alphabet:
+        msg = "alphabet must not be empty"
+        raise InvalidInputError(msg)
+    for symbol in alphabet:
+        if symbol not in transitions:
+            msg = f"transition row missing for symbol {symbol!r}"
+            raise InvalidInputError(msg)
+        if len(transitions[symbol]) != len(alphabet):
+            msg = f"transition row for {symbol!r} has wrong size"
+            raise InvalidInputError(msg)
+    rows = _cumulative_rows(
+        alphabet, {symbol: list(row) for symbol, row in transitions.items()}
+    )
+    start_weights = list(initial) if initial is not None else [1.0] * len(alphabet)
+    if len(start_weights) != len(alphabet):
+        msg = "initial distribution has wrong size"
+        raise InvalidInputError(msg)
+    start = _cumulative_rows(alphabet, {alphabet[0]: start_weights})[alphabet[0]]
+
+    def model(data: Sequence[T], rng: random.Random) -> list[T]:
+        return _generate_chain(alphabet, rows, start, len(data), rng)
+
+    return model
+
+
+def fitted_markov(alphabet: Sequence[T], smoothing: float = 1.0) -> NullModel[T]:
+    """Build a generative null fitting the chain to the observed sequence.
+
+    Each call fits add-`smoothing` smoothed first-order transition counts and
+    the unigram distribution to the observed sequence, then generates a fresh
+    surrogate from that chain. This is the order-1 surrogate standard in
+    surrogate-data testing: it preserves the observed bigram statistics in
+    expectation and randomizes all longer-range structure.
+
+    Args:
+        alphabet: The alphabet the chain runs over
+        smoothing: Pseudo-count added to every transition cell, keeping
+            unseen transitions possible
+
+    Returns:
+        A null model generating length-matched surrogates from the fitted
+        chain
+
+    Raises:
+        InvalidInputError: If the alphabet is empty or smoothing is negative
+    """
+    if not alphabet:
+        msg = "alphabet must not be empty"
+        raise InvalidInputError(msg)
+    if smoothing < 0:
+        msg = f"smoothing must be non-negative, got {smoothing}"
+        raise InvalidInputError(msg)
+    index = {symbol: i for i, symbol in enumerate(alphabet)}
+
+    def model(data: Sequence[T], rng: random.Random) -> list[T]:
+        counts = {symbol: [smoothing] * len(alphabet) for symbol in alphabet}
+        marginal = [smoothing] * len(alphabet)
+        for symbol in data:
+            marginal[index[symbol]] += 1.0
+        for a, b in zip(data, data[1:]):
+            counts[a][index[b]] += 1.0
+        rows = _cumulative_rows(alphabet, counts)
+        start = _cumulative_rows(alphabet, {alphabet[0]: marginal})[alphabet[0]]
+        return _generate_chain(alphabet, rows, start, len(data), rng)
+
+    return model
+
+
+def doublet_markov(alphabet: Sequence[T], rate: float) -> NullModel[T]:
+    """Build a generative null with a pinned self-transition (doublet) rate.
+
+    Each symbol repeats the previous one with probability `rate` and is
+    otherwise uniform over the remaining alphabet; marginals stay uniform.
+    This is the null for text whose only known structure is a suppressed (or
+    enhanced) adjacent-repeat rate: rate = 1/alphabetsize recovers uniform
+    random text, smaller rates model doublet suppression. Statistics judged
+    against a uniform null on such text produce artifacts; this null holds
+    the doublet rate fixed so only structure beyond it can score.
+
+    Args:
+        alphabet: The alphabet to generate over
+        rate: Probability that a symbol equals its predecessor
+
+    Returns:
+        A null model generating length-matched surrogates at the pinned rate
+
+    Raises:
+        InvalidInputError: If the alphabet has fewer than 2 symbols or rate
+            is outside [0, 1]
+    """
+    if len(alphabet) < 2:
+        msg = "doublet_markov needs at least 2 symbols"
+        raise InvalidInputError(msg)
+    if not 0.0 <= rate <= 1.0:
+        msg = f"rate must be in [0, 1], got {rate}"
+        raise InvalidInputError(msg)
+    other = (1.0 - rate) / (len(alphabet) - 1)
+    transitions = {
+        symbol: [rate if candidate == symbol else other for candidate in alphabet]
+        for symbol in alphabet
+    }
+    return markov_model(alphabet, {s: list(row) for s, row in transitions.items()})

--- a/tests/aldegonde/analysis/test_autokey_repeat.py
+++ b/tests/aldegonde/analysis/test_autokey_repeat.py
@@ -1,0 +1,71 @@
+import random
+
+import pytest
+
+from aldegonde.analysis.autokey_repeat import (
+    count_violations,
+    forced_equal_positions,
+)
+from aldegonde.exceptions import InvalidInputError
+
+
+def test_forced_positions_from_a_repeat() -> None:
+    # window 4, depth 1 over a stream with the repeat ABCXY
+    classes = forced_equal_positions(list("ABCXYABCXY"), depth=1, window=4)
+    assert classes == [[1, 6], [2, 7], [3, 8], [4, 9]]
+
+
+def test_depth_zero_links_whole_repeat() -> None:
+    classes = forced_equal_positions(list("ABAB"), depth=0, window=2)
+    # AB occurs at 0 and 2: offsets 0..1 link (0,2) and (1,3)
+    assert classes == [[0, 2], [1, 3]]
+
+
+def test_no_repeats_no_classes() -> None:
+    assert forced_equal_positions(list("ABCDEFGH"), depth=1, window=3) == []
+
+
+def test_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        forced_equal_positions("ABC", depth=-1, window=2)
+    with pytest.raises(InvalidInputError):
+        forced_equal_positions("ABC", depth=1, window=0)
+    with pytest.raises(InvalidInputError):
+        forced_equal_positions("ABC", depth=2, window=2)
+
+
+def test_true_plaintext_has_no_violations() -> None:
+    # build a genuine depth-d ciphertext autokey, decrypt with the true
+    # tableau, and confirm the forced classes are all constant
+    modulus = 5
+    depth = 2
+    rng = random.Random(3)
+    plain = [rng.randrange(modulus) for _ in range(300)]
+    # seed the first `depth` key symbols, then key on prior ciphertext
+    cipher: list[int] = []
+    seed = [rng.randrange(modulus) for _ in range(depth)]
+    for i, p in enumerate(plain):
+        key = seed[i] if i < depth else cipher[i - depth]
+        cipher.append((p + key) % modulus)
+    # decrypt back to the true plaintext
+    recovered: list[int] = []
+    for i, c in enumerate(cipher):
+        key = seed[i] if i < depth else cipher[i - depth]
+        recovered.append((c - key) % modulus)
+    assert recovered == plain
+    classes = forced_equal_positions(cipher, depth=depth, window=depth + 3)
+    assert count_violations(recovered, classes) == 0
+
+
+def test_wrong_plaintext_violates_constraints() -> None:
+    classes = forced_equal_positions(list("ABCXYABCXY"), depth=1, window=4)
+    # a plaintext that is constant satisfies everything
+    assert count_violations(["Q"] * 10, classes) == 0
+    # an all-distinct plaintext violates every class
+    assert count_violations(list("ABCDEFGHIJ"), classes) == len(classes)
+
+
+def test_count_violations_out_of_range_raises() -> None:
+    classes = forced_equal_positions(list("ABCXYABCXY"), depth=1, window=4)
+    with pytest.raises(InvalidInputError):
+        count_violations(["A"] * 3, classes)

--- a/tests/aldegonde/analysis/test_bounds.py
+++ b/tests/aldegonde/analysis/test_bounds.py
@@ -1,0 +1,78 @@
+import pytest
+
+from aldegonde.analysis.bounds import (
+    diagonal_rate,
+    extremal_diagonal_rate,
+    pair_counts,
+)
+from aldegonde.exceptions import InsufficientDataError, InvalidInputError
+
+
+def test_pair_counts_adjacent() -> None:
+    matrix = pair_counts("AABAB", "AB")
+    # pairs: AA, AB, BA, AB
+    assert matrix == [[1, 2], [1, 0]]
+
+
+def test_pair_counts_at_lag() -> None:
+    matrix = pair_counts("ABCABC", "ABC", lag=3)
+    # pairs at lag 3: AA, BB, CC
+    assert matrix == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+
+
+def test_pair_counts_unknown_symbol_raises() -> None:
+    with pytest.raises(InvalidInputError):
+        pair_counts("ABX", "AB")
+    with pytest.raises(InvalidInputError):
+        pair_counts("AB", "AB", lag=0)
+
+
+def test_diagonal_rate_identity_counts_doublets() -> None:
+    matrix = pair_counts("AABAB", "AB")
+    # identity permutation: mass at (A,A) and (B,B) = 1 of 4 pairs
+    assert diagonal_rate(matrix, [0, 1]) == pytest.approx(0.25)
+
+
+def test_diagonal_rate_size_mismatch_raises() -> None:
+    with pytest.raises(InvalidInputError):
+        diagonal_rate([[1, 0], [0, 1]], [0, 1, 2])
+
+
+def test_diagonal_rate_empty_matrix_is_zero() -> None:
+    assert diagonal_rate([[0, 0], [0, 0]], [0, 1]) == 0.0
+
+
+def test_extremal_bounds_bracket_every_permutation() -> None:
+    matrix = pair_counts("AABBCCABCACB" * 5, "ABC")
+    floor = extremal_diagonal_rate(matrix)
+    ceiling = extremal_diagonal_rate(matrix, maximize=True)
+    assert floor.rate <= ceiling.rate
+    # check the bound against the whole symmetric group on 3 points
+    from itertools import permutations
+
+    for candidate in permutations(range(3)):
+        rate = diagonal_rate(matrix, list(candidate))
+        assert floor.rate <= rate + 1e-12
+        assert rate <= ceiling.rate + 1e-12
+
+
+def test_extremal_perm_attains_reported_rate() -> None:
+    matrix = pair_counts("AABBCC" * 10, "ABC")
+    floor = extremal_diagonal_rate(matrix)
+    assert diagonal_rate(matrix, floor.perm) == pytest.approx(floor.rate)
+    sorted_perm = sorted(floor.perm)
+    assert sorted_perm == [0, 1, 2]
+
+
+def test_language_avoiding_pairs_has_zero_floor() -> None:
+    # alternating language never needs a diagonal: some permutation exposes
+    # no doublets at all
+    matrix = pair_counts("ABAB" * 20, "AB")
+    assert extremal_diagonal_rate(matrix).rate == 0.0
+
+
+def test_extremal_validation() -> None:
+    with pytest.raises(InsufficientDataError):
+        extremal_diagonal_rate([])
+    with pytest.raises(InsufficientDataError):
+        extremal_diagonal_rate([[0, 0], [0, 0]])

--- a/tests/aldegonde/analysis/test_coincidence_extras.py
+++ b/tests/aldegonde/analysis/test_coincidence_extras.py
@@ -1,0 +1,100 @@
+import pytest
+
+from aldegonde.analysis.coincidence import (
+    boundary_coincidence,
+    bucket_coincidence,
+    match_separations,
+    within_delta_histogram,
+)
+from aldegonde.exceptions import InvalidInputError
+
+
+def test_boundary_coincidence_digraph_counts_xyxy() -> None:
+    # one word containing AB..AB at distance 3
+    words = [list("ABXAB")]
+    result = boundary_coincidence(words, 3, length=2)
+    assert result.within_observed == 1
+    assert result.within_pairs == 1
+    assert result.across_pairs == 0
+
+
+def test_boundary_coincidence_digraph_spanning_boundary_is_across() -> None:
+    # the second AB spans the word boundary, so the pair is across-word
+    words = [list("ABXA"), list("BY")]
+    result = boundary_coincidence(words, 3, length=2)
+    assert result.within_observed == 0
+    assert result.within_pairs == 0
+    assert result.across_observed == 1
+    assert result.across_pairs == 2
+
+
+def test_boundary_coincidence_length_one_unchanged() -> None:
+    words = [list("ABA"), list("CAB")]
+    a = boundary_coincidence(words, 2)
+    b = boundary_coincidence(words, 2, length=1)
+    assert a == b
+    assert a.within_pairs + a.across_pairs == 4
+
+
+def test_boundary_coincidence_invalid_length() -> None:
+    with pytest.raises(InvalidInputError):
+        boundary_coincidence([list("ABC")], 1, length=0)
+
+
+def test_match_separations_histogram() -> None:
+    # lag-1 matches (doublets) at indicator positions 0, 3, 4
+    separations = match_separations("AAXBBBY", 1)
+    assert separations == {3: 1, 1: 1}
+
+
+def test_match_separations_respects_maximum() -> None:
+    separations = match_separations("AAXBBBY", 1, max_separation=2)
+    assert separations == {1: 1}
+
+
+def test_match_separations_no_matches() -> None:
+    assert match_separations("ABCDEF", 1) == {}
+
+
+def test_within_delta_histogram_counts_by_delta() -> None:
+    words = [list("ABA"), list("CAB"), list("ABA")]
+    histogram = within_delta_histogram(words, "ABC", 1)
+    # within-word lag-1 pairs: AB(+1) BA(+2) CA(+1) AB(+1) AB(+1) BA(+2)
+    assert histogram == [0, 4, 2]
+
+
+def test_within_delta_histogram_bin_zero_is_coincidences() -> None:
+    words = [list("AAB"), list("CC")]
+    histogram = within_delta_histogram(words, "ABC", 1)
+    assert histogram[0] == 2
+
+
+def test_within_delta_histogram_unknown_symbol_raises() -> None:
+    with pytest.raises(InvalidInputError):
+        within_delta_histogram([list("AX")], "AB", 1)
+
+
+def test_bucket_coincidence_shared_key_positions_match() -> None:
+    # positions with the same label always hold the same symbol
+    result = bucket_coincidence("ABABAB", [0, 1, 0, 1, 0, 1])
+    assert result.rate == 1.0
+    assert result.pairs == 6
+
+
+def test_bucket_coincidence_counts_pairs_correctly() -> None:
+    # one bucket of 4 positions holding AABC: pairs C(4,2)=6, matches 1
+    result = bucket_coincidence("AABC", [0, 0, 0, 0])
+    assert result.pairs == 6
+    assert result.observed == 1
+    assert result.rate == pytest.approx(1 / 6)
+
+
+def test_bucket_coincidence_singleton_buckets_have_no_pairs() -> None:
+    result = bucket_coincidence("ABCD", [0, 1, 2, 3])
+    assert result.pairs == 0
+    assert result.rate == 0.0
+
+
+def test_bucket_coincidence_length_mismatch_raises() -> None:
+    with pytest.raises(InvalidInputError):
+        bucket_coincidence("ABC", [0, 1])

--- a/tests/aldegonde/analysis/test_fingerprint.py
+++ b/tests/aldegonde/analysis/test_fingerprint.py
@@ -1,0 +1,53 @@
+import random
+
+import pytest
+
+from aldegonde.analysis.fingerprint import compare, fingerprint
+from aldegonde.exceptions import InsufficientDataError
+
+
+def test_fingerprint_has_expected_keys() -> None:
+    fp = fingerprint("ABCD" * 30, alphabetsize=4, lags=(1, 2, 3))
+    assert set(fp) == {"nioc", "doublet_rate", "kappa_z_1", "kappa_z_2", "kappa_z_3"}
+
+
+def test_fingerprint_doublet_rate() -> None:
+    fp = fingerprint("AABB" * 25, alphabetsize=2)
+    # AABB repeated: doublets at the AA and BB joins, 1 in every 2 adjacencies
+    assert fp["doublet_rate"] == pytest.approx(0.5, abs=0.02)
+
+
+def test_fingerprint_periodic_text_peaks_at_period() -> None:
+    fp = fingerprint("ABCDE" * 40, alphabetsize=5, lags=(1, 5))
+    assert fp["kappa_z_5"] > 5.0
+    assert fp["kappa_z_1"] < 0.0
+
+
+def test_compare_self_distance_is_zero() -> None:
+    fp = fingerprint("ABCDABCD" * 20, alphabetsize=4)
+    assert compare(fp, fp) == 0.0
+
+
+def test_compare_ranks_closer_fingerprint_lower() -> None:
+    rng = random.Random(5)
+    observed = fingerprint([rng.randrange(5) for _ in range(1000)], alphabetsize=5)
+    near = fingerprint([rng.randrange(5) for _ in range(1000)], alphabetsize=5)
+    far = fingerprint("ABCDE" * 200, alphabetsize=5)
+    assert compare(observed, near) < compare(observed, far)
+
+
+def test_compare_uses_scales() -> None:
+    a = {"x": 0.0}
+    b = {"x": 2.0}
+    assert compare(a, b) == pytest.approx(4.0)
+    assert compare(a, b, scales={"x": 2.0}) == pytest.approx(1.0)
+
+
+def test_compare_no_shared_keys_raises() -> None:
+    with pytest.raises(InsufficientDataError):
+        compare({"a": 1.0}, {"b": 2.0})
+
+
+def test_fingerprint_too_short_raises() -> None:
+    with pytest.raises(InsufficientDataError):
+        fingerprint("A")

--- a/tests/aldegonde/analysis/test_fourpoint.py
+++ b/tests/aldegonde/analysis/test_fourpoint.py
@@ -1,0 +1,34 @@
+import random
+
+import pytest
+
+from aldegonde.analysis.fourpoint import fourpoint_coincidence
+from aldegonde.exceptions import InsufficientDataError, InvalidInputError
+
+
+def test_fourpoint_expectation_formula() -> None:
+    result = fourpoint_coincidence("ABCDABCD" * 10, (0, 1, 2, 3), 4)
+    assert result.windows == len(list("ABCDABCD" * 10)) - 3
+    assert result.expected == pytest.approx(result.windows / 16)
+
+
+def test_fourpoint_detects_structure() -> None:
+    # ABAB.. makes positions i,i+2 always equal and i+1,i+3 always equal
+    result = fourpoint_coincidence("AB" * 200, (0, 2, 1, 3), 2)
+    assert result.z > 10.0
+
+
+def test_fourpoint_random_text_near_chance() -> None:
+    rng = random.Random(4)
+    text = [rng.randrange(5) for _ in range(4000)]
+    result = fourpoint_coincidence(text, (0, 1, 2, 3), 5)
+    assert abs(result.z) < 5.0
+
+
+def test_fourpoint_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        fourpoint_coincidence("ABAB", (0, 1, 2, 3), 1)
+    with pytest.raises(InvalidInputError):
+        fourpoint_coincidence("ABAB", (0, -1, 2, 3), 2)
+    with pytest.raises(InsufficientDataError):
+        fourpoint_coincidence("AB", (0, 1, 2, 10), 2)

--- a/tests/aldegonde/analysis/test_keystream.py
+++ b/tests/aldegonde/analysis/test_keystream.py
@@ -1,0 +1,92 @@
+import random
+from collections import Counter
+
+import pytest
+
+from aldegonde.analysis.keystream import autokey_split, offset_scan
+from aldegonde.exceptions import InvalidInputError
+
+MOD = 29
+
+
+def _ioc(pt: list[int]) -> float:
+    counts = Counter(pt)
+    n = len(pt)
+    return sum(v * (v - 1) for v in counts.values()) / (n * (n - 1))
+
+
+def test_offset_scan_recovers_planted_offset() -> None:
+    ks_rng = random.Random(99)
+    keystream = [ks_rng.randrange(MOD) for _ in range(500)]
+    rng = random.Random(4)
+    true_offset = 37
+    # peaked plaintext so the recovered stream scores high on IoC
+    plain = [rng.choices(range(MOD), weights=[12] + [1] * 28)[0] for _ in range(200)]
+    cipher = [(plain[i] + keystream[true_offset + i]) % MOD for i in range(200)]
+    hits = offset_scan(cipher, keystream, MOD, _ioc, subtract=True)
+    best = max(hits, key=lambda h: h.z)
+    assert best.offset == true_offset
+    assert best.z > 5.0
+
+
+def test_offset_scan_reports_every_offset() -> None:
+    hits = offset_scan([1, 2, 3], [0, 0, 0, 0, 0], MOD, _ioc)
+    assert [h.offset for h in hits] == [0, 1, 2]
+
+
+def test_offset_scan_respects_max_offset() -> None:
+    hits = offset_scan([1, 2, 3], list(range(20)), MOD, _ioc, max_offset=5)
+    assert [h.offset for h in hits] == list(range(6))
+
+
+def test_offset_scan_beaufort_direction() -> None:
+    # add direction: plain = key - cipher
+    keystream = list(range(10))
+    cipher = [3, 4, 5]
+    hits = offset_scan(cipher, keystream, MOD, _ioc, subtract=False)
+    assert hits  # runs without error over the add direction
+
+
+def test_offset_scan_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        offset_scan([1, 2, 3], [0], MOD, _ioc)  # keystream too short
+    with pytest.raises(InvalidInputError):
+        offset_scan([1, 2], [0, 0], 0, _ioc)  # bad modulus
+
+
+def test_autokey_split_detects_ciphertext_autokey() -> None:
+    rng = random.Random(7)
+    plain = [
+        rng.choices(range(MOD), weights=[10, 8, 6] + [1] * 26)[0] for _ in range(3000)
+    ]
+    cipher = [plain[0]]
+    for i in range(1, len(plain)):
+        cipher.append((plain[i] + cipher[i - 1]) % MOD)
+    hit = autokey_split(cipher, 1, alphabetsize=MOD)
+    assert hit.pooled_ioc > 1.3
+
+
+def test_autokey_split_flat_on_random_text() -> None:
+    rng = random.Random(11)
+    stream = [rng.randrange(MOD) for _ in range(3000)]
+    hit = autokey_split(stream, 1, alphabetsize=MOD)
+    assert abs(hit.pooled_ioc - 1.0) < 0.2
+
+
+def test_autokey_split_wrong_depth_stays_flat() -> None:
+    rng = random.Random(7)
+    plain = [
+        rng.choices(range(MOD), weights=[10, 8, 6] + [1] * 26)[0] for _ in range(3000)
+    ]
+    cipher = [plain[0]]
+    for i in range(1, len(plain)):
+        cipher.append((plain[i] + cipher[i - 1]) % MOD)
+    # true depth is 1; depth 7 should not show the lift
+    right = autokey_split(cipher, 1, alphabetsize=MOD).pooled_ioc
+    wrong = autokey_split(cipher, 7, alphabetsize=MOD).pooled_ioc
+    assert right > wrong
+
+
+def test_autokey_split_invalid_depth() -> None:
+    with pytest.raises(InvalidInputError):
+        autokey_split([1, 2, 3], 0)

--- a/tests/aldegonde/analysis/test_relations.py
+++ b/tests/aldegonde/analysis/test_relations.py
@@ -1,0 +1,61 @@
+import random
+
+import pytest
+
+from aldegonde.analysis.relations import (
+    linear_relation_scan,
+    positional_relation_scan,
+)
+from aldegonde.exceptions import InvalidInputError
+
+ABC = "ABCDE"
+
+
+def test_additive_progression_detected() -> None:
+    # x[i+1] = x[i] + 1 mod 5, so x[i+1] + 4*x[i] = constant + 5*x[i] is
+    # degenerate at coefficient N-1 (the subtractive relation)
+    text = [ABC[i % 5] for i in range(300)]
+    scan = linear_relation_scan(text, ABC, lags=[1])
+    assert scan[(1, 4)].p < 1e-9
+
+
+def test_random_text_scan_is_flat() -> None:
+    rng = random.Random(17)
+    text = [rng.choice(ABC) for _ in range(3000)]
+    scan = linear_relation_scan(text, ABC, lags=[1, 2, 3])
+    # 12 cells scanned; nothing should be extreme beyond a Bonferroni cut
+    assert all(result.p > 1e-4 for result in scan.values())
+
+
+def test_scan_covers_requested_grid() -> None:
+    text = [random.Random(1).choice(ABC) for _ in range(100)]
+    scan = linear_relation_scan(text, ABC, lags=[1, 2], coefficients=[1, 2])
+    assert set(scan) == {(1, 1), (1, 2), (2, 1), (2, 2)}
+
+
+def test_short_text_omits_impossible_lags() -> None:
+    scan = linear_relation_scan("ABAB", "AB", lags=[1, 10], coefficients=[1])
+    assert (1, 1) in scan
+    assert all(lag != 10 for lag, _ in scan)
+
+
+def test_invalid_inputs_raise() -> None:
+    with pytest.raises(InvalidInputError):
+        linear_relation_scan("ABAB", "AB", lags=[0], coefficients=[1])
+    with pytest.raises(InvalidInputError):
+        linear_relation_scan("ABX", "AB", lags=[1])
+
+
+def test_positional_drift_detected() -> None:
+    # x[i] = -2*i mod 5: adding 2*i makes the stream constant
+    text = [ABC[(-2 * i) % 5] for i in range(300)]
+    scan = positional_relation_scan(text, ABC)
+    assert scan[2].p < 1e-9
+    assert scan[1].p > 1e-4
+
+
+def test_positional_scan_flat_on_random_text() -> None:
+    rng = random.Random(23)
+    text = [rng.choice(ABC) for _ in range(3000)]
+    scan = positional_relation_scan(text, ABC)
+    assert all(result.p > 1e-4 for result in scan.values())

--- a/tests/aldegonde/analysis/test_spectral.py
+++ b/tests/aldegonde/analysis/test_spectral.py
@@ -1,0 +1,80 @@
+import random
+
+import pytest
+
+from aldegonde.analysis.spectral import (
+    crosscorrelation_coincidence,
+    multiplier_dft,
+)
+from aldegonde.exceptions import InsufficientDataError, InvalidInputError
+
+A = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012"[:29]
+
+
+def test_crosscorrelation_finds_known_shift() -> None:
+    rng = random.Random(1)
+    n = 400
+    s = [A[rng.randrange(29)] for _ in range(n)]
+    shift = 7
+    # second[i] = s[(i - shift) mod n]; first[i] aligns second[i + shift]
+    second = s[-shift:] + s[:-shift]
+    peak = crosscorrelation_coincidence(s, second, A)
+    assert peak.shift == shift
+    assert peak.coincidences == n
+    assert peak.z > 10.0
+
+
+def test_crosscorrelation_negative_shift() -> None:
+    rng = random.Random(2)
+    n = 200
+    s = [A[rng.randrange(29)] for _ in range(n)]
+    shift = 5
+    # rotate the other way: second[i] = s[(i + shift) mod n]
+    second = s[shift:] + s[:shift]
+    peak = crosscorrelation_coincidence(s, second, A)
+    assert peak.shift == -shift
+
+
+def test_crosscorrelation_unrelated_streams_low_z() -> None:
+    rng = random.Random(3)
+    a = [A[rng.randrange(29)] for _ in range(400)]
+    b = [A[rng.randrange(29)] for _ in range(400)]
+    peak = crosscorrelation_coincidence(a, b, A)
+    assert peak.z < 6.0
+
+
+def test_crosscorrelation_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        crosscorrelation_coincidence("ABC", "AB", A)
+    with pytest.raises(InsufficientDataError):
+        crosscorrelation_coincidence([], [], A)
+    with pytest.raises(InvalidInputError):
+        crosscorrelation_coincidence("AZ", "AB", "AB")
+
+
+def test_multiplier_dft_detects_periodic_component() -> None:
+    text = [A[(3 * i) % 29] for i in range(300)]
+    peak = multiplier_dft(text, A)
+    assert peak.power > peak.threshold
+
+
+def test_multiplier_dft_random_below_threshold() -> None:
+    rng = random.Random(5)
+    text = [A[rng.randrange(29)] for _ in range(300)]
+    peak = multiplier_dft(text, A)
+    assert peak.power < peak.threshold
+
+
+def test_multiplier_dft_threshold_covers_multiplier_scan() -> None:
+    # the threshold must grow with the number of multipliers scanned
+    text = [A[(3 * i) % 29] for i in range(300)]
+    wide = multiplier_dft(text, A)
+    narrow = multiplier_dft(text, A, multipliers=[3])
+    assert wide.threshold > narrow.threshold
+
+
+def test_multiplier_dft_validation() -> None:
+    with pytest.raises(InsufficientDataError):
+        multiplier_dft("A", A)
+    with pytest.raises(InvalidInputError):
+        multiplier_dft("XY", "AB")

--- a/tests/aldegonde/maths/test_sequences.py
+++ b/tests/aldegonde/maths/test_sequences.py
@@ -1,0 +1,83 @@
+import pytest
+
+from aldegonde.exceptions import InvalidInputError
+from aldegonde.maths.sequences import (
+    catalogue,
+    fibonacci,
+    linear_recurrence,
+    lucas,
+    moebius_sequence,
+    naturals,
+    polygonal,
+    prime_gaps,
+    primes,
+    totients,
+    triangular,
+)
+
+
+def test_primes_first_n() -> None:
+    assert primes(6) == [2, 3, 5, 7, 11, 13]
+    assert primes(0) == []
+    assert primes(1) == [2]
+    assert len(primes(100)) == 100
+
+
+def test_prime_gaps() -> None:
+    assert prime_gaps(5) == [1, 2, 2, 4, 2]
+
+
+def test_naturals() -> None:
+    assert naturals(4) == [0, 1, 2, 3]
+    assert naturals(3, start=10) == [10, 11, 12]
+
+
+def test_totients() -> None:
+    # phi(1..6) = 1,1,2,2,4,2
+    assert totients(6) == [1, 1, 2, 2, 4, 2]
+
+
+def test_moebius_sequence() -> None:
+    # mu(1..6) = 1,-1,-1,0,-1,1
+    assert moebius_sequence(6) == [1, -1, -1, 0, -1, 1]
+
+
+def test_triangular_and_polygonal() -> None:
+    assert triangular(5) == [1, 3, 6, 10, 15]
+    assert polygonal(5, 3) == triangular(5)
+    assert polygonal(5, 4) == [1, 4, 9, 16, 25]
+    assert polygonal(4, 5) == [1, 5, 12, 22]
+
+
+def test_linear_recurrence_families() -> None:
+    assert fibonacci(8) == [0, 1, 1, 2, 3, 5, 8, 13]
+    assert lucas(6) == [2, 1, 3, 4, 7, 11]
+    tribonacci = linear_recurrence(8, [0, 0, 1], [1, 1, 1])
+    assert tribonacci == [0, 0, 1, 1, 2, 4, 7, 13]
+
+
+def test_linear_recurrence_short_request() -> None:
+    assert fibonacci(0) == []
+    assert fibonacci(1) == [0]
+    assert fibonacci(2) == [0, 1]
+
+
+def test_catalogue_uniform_length() -> None:
+    cat = catalogue(7)
+    assert all(len(seq) == 7 for seq in cat.values())
+    assert "primes" in cat
+    assert "fibonacci" in cat
+    assert cat["squares"] == polygonal(7, 4)
+
+
+def test_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        primes(-1)
+    with pytest.raises(InvalidInputError):
+        polygonal(5, 2)
+    with pytest.raises(InvalidInputError):
+        totients(5, start=0)
+    with pytest.raises(InvalidInputError):
+        linear_recurrence(5, [], [])
+    with pytest.raises(InvalidInputError):
+        linear_recurrence(5, [1, 1], [1])

--- a/tests/aldegonde/search/test_cascade.py
+++ b/tests/aldegonde/search/test_cascade.py
@@ -1,0 +1,61 @@
+import pytest
+
+from aldegonde.exceptions import InvalidInputError
+from aldegonde.search.cascade import filter_cascade
+
+
+def test_cascade_funnels_and_reports() -> None:
+    survivors, reports = filter_cascade(
+        range(30),
+        [
+            ("even", lambda x: x % 2 == 0),
+            ("div3", lambda x: x % 3 == 0),
+        ],
+    )
+    assert survivors == [0, 6, 12, 18, 24]
+    assert reports[0].entered == 30
+    assert reports[0].survived == 15
+    assert reports[1].entered == 15
+    assert reports[1].survived == 5
+
+
+def test_cascade_stops_evaluating_dropped_candidates() -> None:
+    seen: list[int] = []
+
+    def expensive(x: int) -> bool:
+        seen.append(x)
+        return True
+
+    filter_cascade(
+        range(10),
+        [("cheap", lambda x: x < 3), ("expensive", expensive)],
+    )
+    # only the 3 survivors of the cheap stage reach the expensive one
+    assert sorted(seen) == [0, 1, 2]
+
+
+def test_cascade_all_survive() -> None:
+    survivors, reports = filter_cascade([1, 2, 3], [("all", lambda _x: True)])
+    assert survivors == [1, 2, 3]
+    assert reports[0].survived == 3
+
+
+def test_cascade_none_survive() -> None:
+    survivors, reports = filter_cascade([1, 2, 3], [("none", lambda _x: False)])
+    assert survivors == []
+    assert reports[0].survived == 0
+
+
+def test_cascade_requires_a_stage() -> None:
+    with pytest.raises(InvalidInputError):
+        filter_cascade([1, 2, 3], [])
+
+
+def test_cascade_self_test_pattern() -> None:
+    # plant a known-good candidate and confirm the cascade passes it
+    stages = [
+        ("positive", lambda x: x > 0),
+        ("even", lambda x: x % 2 == 0),
+    ]
+    survivors, _ = filter_cascade([4], stages)
+    assert survivors == [4]

--- a/tests/aldegonde/search/test_hillclimb.py
+++ b/tests/aldegonde/search/test_hillclimb.py
@@ -1,0 +1,140 @@
+import random
+
+import pytest
+
+from aldegonde import perm
+from aldegonde.exceptions import InvalidInputError
+from aldegonde.search.hillclimb import (
+    conjugation_neighbor,
+    hill_climb,
+    multi_start,
+    swap_neighbor,
+)
+
+ABC = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def _match_score(target: str):
+    def score(candidate: list[str]) -> float:
+        return sum(a == b for a, b in zip(candidate, target))
+
+    return score
+
+
+def test_hill_climb_reaches_optimum() -> None:
+    target = list("DCBA" * 3)
+    score = _match_score(target)
+    start = sorted(target)
+    result = hill_climb(
+        start, swap_neighbor, score, iterations=5000, rng=random.Random(0)
+    )
+    assert result.state == target
+    assert result.score == len(target)
+    assert result.improvements <= result.proposals
+
+
+def test_hill_climb_never_worsens() -> None:
+    target = list("ZYXWVU")
+    result = hill_climb(
+        sorted(target),
+        swap_neighbor,
+        _match_score(target),
+        iterations=2000,
+        rng=random.Random(1),
+    )
+    assert result.score >= sum(a == b for a, b in zip(sorted(target), target))
+
+
+def test_stagnation_stops_early() -> None:
+    # constant score: every proposal stagnates, so it stops after `stagnation`
+    result = hill_climb(
+        list("AB"),
+        swap_neighbor,
+        lambda _s: 1.0,
+        iterations=10_000,
+        stagnation=50,
+        rng=random.Random(2),
+    )
+    assert result.proposals == 50
+
+
+def test_hill_climb_invalid_args() -> None:
+    with pytest.raises(InvalidInputError):
+        hill_climb([1, 2], swap_neighbor, sum, iterations=0, rng=random.Random(0))
+    with pytest.raises(InvalidInputError):
+        hill_climb([1, 2], swap_neighbor, sum, stagnation=0, rng=random.Random(0))
+
+
+def test_multi_start_is_reproducible() -> None:
+    target = list("HGFEDCBA")
+
+    def factory(r: random.Random) -> list[str]:
+        return r.sample(target, len(target))
+
+    a, _ = multi_start(factory, swap_neighbor, _match_score(target), starts=4, seed=5)
+    b, _ = multi_start(factory, swap_neighbor, _match_score(target), starts=4, seed=5)
+    assert a.state == b.state
+    assert a.score == b.score
+
+
+def test_multi_start_returns_best_and_all() -> None:
+    target = list("BADCFE")
+    best, results = multi_start(
+        lambda r: r.sample(target, len(target)),
+        swap_neighbor,
+        _match_score(target),
+        starts=5,
+        seed=0,
+    )
+    assert len(results) == 5
+    assert best.score == max(r.score for r in results)
+
+
+def test_multi_start_invalid_starts() -> None:
+    with pytest.raises(InvalidInputError):
+        multi_start(lambda r: [0], swap_neighbor, sum, starts=0)
+
+
+def test_planted_substitution_key_recovered() -> None:
+    # encrypt known plaintext with a known key; the climber must recover it
+    rng = random.Random(7)
+    plaintext = [rng.choice("ETAOINSHRD") for _ in range(500)]
+    key = list(ABC)
+    random.Random(11).shuffle(key)
+    enc = dict(zip(ABC, key))
+    cipher = [enc[p] for p in plaintext]
+
+    def score(candidate: list[str]) -> float:
+        dec = {c: p for p, c in zip(ABC, candidate)}
+        return sum(dec[c] == p for c, p in zip(cipher, plaintext))
+
+    best, _ = multi_start(
+        lambda r: r.sample(ABC, 26),
+        swap_neighbor,
+        score,
+        starts=8,
+        iterations=5000,
+        stagnation=1000,
+        seed=1,
+    )
+    assert best.score == len(cipher)
+
+
+def test_swap_neighbor_changes_two_positions() -> None:
+    state = list(range(10))
+    out = swap_neighbor(state, random.Random(0))
+    differing = [i for i in range(10) if out[i] != state[i]]
+    assert len(differing) == 2
+    assert sorted(out) == state
+
+
+def test_swap_neighbor_too_short_raises() -> None:
+    with pytest.raises(InvalidInputError):
+        swap_neighbor([1], random.Random(0))
+
+
+def test_conjugation_neighbor_preserves_cycle_type() -> None:
+    g = perm.from_cycle_type([4, 3, 2], 9)
+    for seed in range(10):
+        mutated = conjugation_neighbor(g, random.Random(seed))
+        assert perm.cycle_type(mutated) == perm.cycle_type(g)

--- a/tests/aldegonde/sim/test_markov.py
+++ b/tests/aldegonde/sim/test_markov.py
@@ -1,0 +1,65 @@
+import random
+
+import pytest
+
+from aldegonde.exceptions import InsufficientDataError, InvalidInputError
+from aldegonde.sim.markov import cut_by_lengths, fit_markov, generate
+
+
+def test_generate_length_and_alphabet() -> None:
+    training = list("ABCABCABC" * 10)
+    model = fit_markov(training, order=1)
+    out = generate(model, 50, random.Random(0))
+    assert len(out) == 50
+    assert set(out) <= set("ABC")
+
+
+def test_generate_is_seeded() -> None:
+    model = fit_markov(list("ABCDABCD" * 20), order=2, smoothing=0.1)
+    a = generate(model, 100, random.Random(3))
+    b = generate(model, 100, random.Random(3))
+    assert a == b
+
+
+def test_generate_reproduces_deterministic_structure() -> None:
+    # a strictly cyclic training text yields a model that continues the cycle
+    model = fit_markov(list("ABC" * 20), order=1)
+    out = generate(model, 30, random.Random(1))
+    # every A is followed by B, every B by C, every C by A
+    for x, y in zip(out, out[1:]):
+        assert (x, y) in {("A", "B"), ("B", "C"), ("C", "A")}
+
+
+def test_generate_zero_length() -> None:
+    model = fit_markov(list("ABAB" * 5), order=1)
+    assert generate(model, 0, random.Random(0)) == []
+
+
+def test_fit_markov_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        fit_markov(list("ABC"), order=0)
+    with pytest.raises(InvalidInputError):
+        fit_markov(list("ABC"), order=1, smoothing=-1.0)
+    with pytest.raises(InsufficientDataError):
+        fit_markov(list("A"), order=2)
+
+
+def test_cut_by_lengths_preserves_all_symbols() -> None:
+    stream = list(range(100))
+    words = cut_by_lengths(stream, {3: 5, 4: 3, 5: 2}, random.Random(2))
+    assert sum(len(w) for w in words) == 100
+    assert [s for w in words for s in w] == stream
+
+
+def test_cut_by_lengths_single_length() -> None:
+    words = cut_by_lengths(list("ABCDEF"), {2: 1.0}, random.Random(0))
+    assert words == [list("AB"), list("CD"), list("EF")]
+
+
+def test_cut_by_lengths_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        cut_by_lengths([1, 2, 3], {}, random.Random(0))
+    with pytest.raises(InvalidInputError):
+        cut_by_lengths([1, 2, 3], {0: 1.0}, random.Random(0))
+    with pytest.raises(InvalidInputError):
+        cut_by_lengths([1, 2, 3], {2: 0.0}, random.Random(0))

--- a/tests/aldegonde/stats/test_binomial.py
+++ b/tests/aldegonde/stats/test_binomial.py
@@ -1,0 +1,81 @@
+import pytest
+
+from aldegonde.exceptions import InvalidInputError
+from aldegonde.stats.binomial import (
+    coincidence_z,
+    two_proportion_z,
+    wilson_interval,
+)
+
+
+def test_coincidence_z_at_chance_is_near_zero() -> None:
+    # exactly the expected count under 1/29
+    z = coincidence_z(round(2900 / 29), 2900, 29)
+    assert abs(z) < 0.5
+
+
+def test_coincidence_z_excess_is_positive() -> None:
+    assert coincidence_z(200, 2900, 29) > 5.0
+
+
+def test_coincidence_z_zero_opportunities() -> None:
+    assert coincidence_z(0, 0, 29) == 0.0
+
+
+def test_coincidence_z_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        coincidence_z(5, 10, 1)
+    with pytest.raises(InvalidInputError):
+        coincidence_z(11, 10, 5)
+    with pytest.raises(InvalidInputError):
+        coincidence_z(-1, 10, 5)
+
+
+def test_wilson_interval_brackets_estimate() -> None:
+    result = wilson_interval(5, 100)
+    assert result.estimate == 0.05
+    assert result.low < 0.05 < result.high
+    assert result.low >= 0.0
+
+
+def test_wilson_interval_handles_zero_hits() -> None:
+    result = wilson_interval(0, 50)
+    assert result.estimate == 0.0
+    assert result.low == pytest.approx(0.0, abs=1e-12)
+    assert result.high > 0.0
+
+
+def test_wilson_interval_handles_all_hits() -> None:
+    result = wilson_interval(50, 50)
+    assert result.estimate == 1.0
+    assert result.high == 1.0
+    assert result.low < 1.0
+
+
+def test_wilson_interval_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        wilson_interval(5, 0)
+    with pytest.raises(InvalidInputError):
+        wilson_interval(11, 10)
+    with pytest.raises(InvalidInputError):
+        wilson_interval(5, 10, z=-1.0)
+
+
+def test_two_proportion_z_detects_difference() -> None:
+    # 30% vs 10% over 100 trials each
+    assert two_proportion_z(30, 100, 10, 100) > 3.0
+
+
+def test_two_proportion_z_equal_rates_near_zero() -> None:
+    assert abs(two_proportion_z(20, 100, 40, 200)) < 0.5
+
+
+def test_two_proportion_z_sign() -> None:
+    assert two_proportion_z(10, 100, 30, 100) < 0.0
+
+
+def test_two_proportion_z_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        two_proportion_z(5, 0, 5, 10)
+    with pytest.raises(InvalidInputError):
+        two_proportion_z(11, 10, 5, 10)

--- a/tests/aldegonde/stats/test_chisq.py
+++ b/tests/aldegonde/stats/test_chisq.py
@@ -1,0 +1,125 @@
+import random
+
+import pytest
+
+from aldegonde.exceptions import InsufficientDataError, InvalidInputError
+from aldegonde.stats.chisq import (
+    goodness_of_fit,
+    lag_contingency,
+    rate_uniformity,
+    uniformity,
+    wilson_hilferty,
+)
+
+
+def test_wilson_hilferty_centers_near_zero_at_df() -> None:
+    # chi2 equal to its df is unremarkable: |z| should be small
+    assert abs(wilson_hilferty(10.0, 10)) < 0.5
+    # far above df: strongly positive
+    assert wilson_hilferty(50.0, 10) > 4.5
+
+
+def test_wilson_hilferty_invalid_inputs() -> None:
+    with pytest.raises(InvalidInputError):
+        wilson_hilferty(1.0, 0)
+    with pytest.raises(InvalidInputError):
+        wilson_hilferty(-1.0, 5)
+
+
+def test_uniformity_flat_counts_not_significant() -> None:
+    result = uniformity([100, 101, 99, 100])
+    assert result.df == 3
+    assert result.p > 0.9
+
+
+def test_uniformity_skewed_counts_significant() -> None:
+    result = uniformity([200, 10, 10, 10])
+    assert result.p < 1e-6
+    assert result.z > 3.0
+
+
+def test_uniformity_needs_data() -> None:
+    with pytest.raises(InsufficientDataError):
+        uniformity([5])
+    with pytest.raises(InsufficientDataError):
+        uniformity([0, 0, 0])
+
+
+def test_goodness_of_fit_matches_uniformity_for_flat_weights() -> None:
+    counts = [30, 50, 20]
+    assert goodness_of_fit(counts, [1.0, 1.0, 1.0]).chi2 == pytest.approx(
+        uniformity(counts).chi2
+    )
+
+
+def test_goodness_of_fit_perfect_fit() -> None:
+    result = goodness_of_fit([30, 60, 10], [3.0, 6.0, 1.0])
+    assert result.chi2 == pytest.approx(0.0)
+    assert result.p == pytest.approx(1.0)
+
+
+def test_goodness_of_fit_zero_weight_with_count_raises() -> None:
+    with pytest.raises(InvalidInputError):
+        goodness_of_fit([5, 5], [1.0, 0.0])
+
+
+def test_goodness_of_fit_length_mismatch_raises() -> None:
+    with pytest.raises(InvalidInputError):
+        goodness_of_fit([5, 5], [1.0])
+
+
+def test_rate_uniformity_flat_rate_not_significant() -> None:
+    # same 5% rate everywhere despite very different exposures
+    result = rate_uniformity({"a": (1000, 50), "b": (100, 5), "c": (400, 20)})
+    assert result.p > 0.9
+
+
+def test_rate_uniformity_detects_rate_difference() -> None:
+    # equal event counts would fool a frequency test; the rates differ 10x
+    result = rate_uniformity({"a": (1000, 20), "b": (100, 20)})
+    assert result.p < 1e-6
+
+
+def test_rate_uniformity_invalid_bins() -> None:
+    with pytest.raises(InvalidInputError):
+        rate_uniformity({"a": (10, 20), "b": (10, 1)})
+    with pytest.raises(InsufficientDataError):
+        rate_uniformity({"a": (10, 1)})
+    with pytest.raises(InsufficientDataError):
+        rate_uniformity({"a": (10, 0), "b": (10, 0)})
+
+
+def test_lag_contingency_detects_dependence() -> None:
+    # strictly alternating text: symbol at i+1 is determined by symbol at i
+    result = lag_contingency("AB" * 100, 1)
+    assert result.p < 1e-6
+
+
+def test_lag_contingency_independent_text_not_significant() -> None:
+    rng = random.Random(7)
+    text = [rng.choice("ABCD") for _ in range(2000)]
+    result = lag_contingency(text, 1)
+    assert result.p > 0.01
+
+
+def test_lag_contingency_off_diagonal_masks_doublet_structure() -> None:
+    # text whose only structure is never repeating: full table is significant,
+    # the off-diagonal table is not
+    rng = random.Random(3)
+    alphabet = "ABCDE"
+    text = ["A"]
+    for _ in range(3000):
+        text.append(rng.choice([s for s in alphabet if s != text[-1]]))
+    assert lag_contingency(text, 1).p < 1e-6
+    masked = lag_contingency(text, 1, off_diagonal=True)
+    assert masked.p > 0.01
+    assert masked.df == (5 - 1) * (5 - 1) - 5
+
+
+def test_lag_contingency_invalid_inputs() -> None:
+    with pytest.raises(InvalidInputError):
+        lag_contingency("ABAB", 0)
+    with pytest.raises(InsufficientDataError):
+        lag_contingency("AB", 5)
+    with pytest.raises(InsufficientDataError):
+        lag_contingency("AAAA", 1)

--- a/tests/aldegonde/stats/test_kappa_spectrum.py
+++ b/tests/aldegonde/stats/test_kappa_spectrum.py
@@ -1,0 +1,55 @@
+import random
+
+import pytest
+
+from aldegonde.exceptions import InsufficientDataError
+from aldegonde.stats.kappa import kappa_spectrum
+
+
+def test_periodic_text_peaks_at_multiples_of_period() -> None:
+    spectrum = kappa_spectrum("ABCDE" * 40, range(1, 11))
+    for skip in (5, 10):
+        assert spectrum[skip].z > 5.0
+    for skip in (1, 2, 3, 4, 6, 7, 8, 9):
+        assert spectrum[skip].z < 0.0
+
+
+def test_random_text_spectrum_is_flat() -> None:
+    rng = random.Random(11)
+    text = [rng.choice("ABCDEFGH") for _ in range(4000)]
+    spectrum = kappa_spectrum(text, range(1, 21))
+    assert all(abs(result.z) < 4.0 for result in spectrum.values())
+
+
+def test_frequency_matched_null_absorbs_skew() -> None:
+    # heavily skewed frequencies inflate coincidences at every skip; the
+    # frequency-matched null must not read that as periodicity
+    rng = random.Random(13)
+    text = rng.choices("AB", weights=[9, 1], k=5000)
+    spectrum = kappa_spectrum(text, range(1, 11))
+    assert all(abs(result.z) < 4.0 for result in spectrum.values())
+
+
+def test_expected_uses_frequency_rate() -> None:
+    text = "AABB" * 100
+    spectrum = kappa_spectrum(text, [1])
+    result = spectrum[1]
+    # frequencies are flat over 2 symbols: chance rate 1/2
+    assert result.expected == pytest.approx(result.comparisons * 0.5)
+
+
+def test_digraphic_spectrum() -> None:
+    spectrum = kappa_spectrum("ABCABC" * 30, [3, 4], length=2)
+    assert spectrum[3].z > 5.0
+    assert spectrum[4].z < 0.0
+
+
+def test_skips_beyond_text_are_omitted() -> None:
+    spectrum = kappa_spectrum("ABCD", [1, 10])
+    assert 1 in spectrum
+    assert 10 not in spectrum
+
+
+def test_empty_text_raises() -> None:
+    with pytest.raises(InsufficientDataError):
+        kappa_spectrum([], [1])

--- a/tests/aldegonde/stats/test_markov_nulls.py
+++ b/tests/aldegonde/stats/test_markov_nulls.py
@@ -1,0 +1,94 @@
+import random
+from collections import Counter
+
+import pytest
+
+from aldegonde.exceptions import InvalidInputError
+from aldegonde.stats.nulls import doublet_markov, fitted_markov, markov_model
+
+ABC = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def _doublet_rate(seq: list[str]) -> float:
+    return sum(1 for a, b in zip(seq, seq[1:]) if a == b) / (len(seq) - 1)
+
+
+def test_markov_model_matches_length_only() -> None:
+    null = markov_model("AB", {"A": [0.0, 1.0], "B": [1.0, 0.0]})
+    out = null(list("AAAAAA"), random.Random(0))
+    assert len(out) == 6
+    # deterministic alternating chain: no two adjacent symbols equal
+    assert all(a != b for a, b in zip(out, out[1:]))
+
+
+def test_markov_model_is_seeded_and_varies() -> None:
+    null = markov_model("ABC", {s: [1.0, 1.0, 1.0] for s in "ABC"})
+    data = list("A" * 50)
+    assert null(data, random.Random(5)) == null(data, random.Random(5))
+    assert null(data, random.Random(5)) != null(data, random.Random(6))
+
+
+def test_markov_model_respects_initial_distribution() -> None:
+    null = markov_model("AB", {"A": [1.0, 1.0], "B": [1.0, 1.0]}, initial=[1.0, 0.0])
+    for seed in range(20):
+        assert null(["A"], random.Random(seed))[0] == "A"
+
+
+def test_markov_model_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        markov_model("", {})
+    with pytest.raises(InvalidInputError):
+        markov_model("AB", {"A": [1.0, 1.0]})  # row missing for B
+    with pytest.raises(InvalidInputError):
+        markov_model("AB", {"A": [1.0], "B": [1.0, 1.0]})  # wrong size
+    with pytest.raises(InvalidInputError):
+        markov_model("AB", {"A": [0.0, 0.0], "B": [1.0, 1.0]})  # zero row
+    with pytest.raises(InvalidInputError):
+        markov_model("AB", {"A": [-1.0, 2.0], "B": [1.0, 1.0]})  # negative
+
+
+def test_doublet_markov_hits_target_rate() -> None:
+    target = 0.02
+    null = doublet_markov(list(ABC), target)
+    surrogate = null(["A"] * 20000, random.Random(1))
+    assert _doublet_rate(list(surrogate)) == pytest.approx(target, abs=0.005)
+
+
+def test_doublet_markov_zero_rate_forbids_doublets() -> None:
+    null = doublet_markov("ABCDE", 0.0)
+    surrogate = null(["A"] * 2000, random.Random(2))
+    assert _doublet_rate(list(surrogate)) == 0.0
+
+
+def test_doublet_markov_marginals_roughly_uniform() -> None:
+    null = doublet_markov("ABCD", 0.01)
+    counts = Counter(null(["A"] * 20000, random.Random(3)))
+    for symbol in "ABCD":
+        assert counts[symbol] == pytest.approx(5000, rel=0.1)
+
+
+def test_doublet_markov_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        doublet_markov("A", 0.1)
+    with pytest.raises(InvalidInputError):
+        doublet_markov("AB", 1.5)
+
+
+def test_fitted_markov_reproduces_transition_bias() -> None:
+    # data where A is nearly always followed by B
+    data = list("AB" * 500)
+    null = fitted_markov("AB", smoothing=0.5)
+    surrogate = null(data, random.Random(4))
+    follows_b = sum(
+        1 for a, b in zip(surrogate, surrogate[1:]) if a == "A" and b == "B"
+    )
+    a_count = sum(1 for s in surrogate[:-1] if s == "A")
+    assert a_count > 0
+    assert follows_b / a_count > 0.9
+
+
+def test_fitted_markov_validation() -> None:
+    with pytest.raises(InvalidInputError):
+        fitted_markov("")
+    with pytest.raises(InvalidInputError):
+        fitted_markov("AB", smoothing=-1.0)

--- a/tests/aldegonde/stats/test_multitest.py
+++ b/tests/aldegonde/stats/test_multitest.py
@@ -1,0 +1,69 @@
+from math import log, sqrt
+
+import pytest
+
+from aldegonde.exceptions import InvalidInputError
+from aldegonde.stats.multitest import (
+    bonferroni,
+    bonferroni_threshold,
+    expected_max_z,
+    multiplicity_budget,
+    sidak,
+    sidak_threshold,
+)
+
+
+def test_bonferroni_scales_and_caps() -> None:
+    assert bonferroni(0.01, 5) == pytest.approx(0.05)
+    assert bonferroni(0.5, 10) == 1.0
+
+
+def test_bonferroni_single_test_is_identity() -> None:
+    assert bonferroni(0.037, 1) == pytest.approx(0.037)
+
+
+def test_sidak_less_conservative_than_bonferroni() -> None:
+    assert sidak(0.01, 5) < bonferroni(0.01, 5)
+    assert sidak(0.01, 5) == pytest.approx(1 - 0.99**5)
+
+
+def test_thresholds_invert_corrections() -> None:
+    assert bonferroni_threshold(0.05, 20) == pytest.approx(0.0025)
+    # applying sidak to its own threshold recovers the family-wise level
+    per_test = sidak_threshold(0.05, 20)
+    assert sidak(per_test, 20) == pytest.approx(0.05)
+
+
+def test_invalid_inputs_raise() -> None:
+    with pytest.raises(InvalidInputError):
+        bonferroni(1.5, 5)
+    with pytest.raises(InvalidInputError):
+        bonferroni(0.01, 0)
+    with pytest.raises(InvalidInputError):
+        sidak(-0.1, 5)
+    with pytest.raises(InvalidInputError):
+        expected_max_z(0)
+
+
+def test_expected_max_z_value() -> None:
+    assert expected_max_z(1) == 0.0
+    assert expected_max_z(100) == pytest.approx(sqrt(2 * log(100)))
+
+
+def test_multiplicity_budget_counts_two_sided() -> None:
+    result = multiplicity_budget([0.1, 2.5, -3.0, 1.9], 2.0)
+    assert result.observed == 2
+    assert result.tests == 4
+    # two-sided normal tail at 2.0 is about 4.55% per test
+    assert result.expected == pytest.approx(4 * 0.0455, abs=0.001)
+
+
+def test_multiplicity_budget_one_sided() -> None:
+    result = multiplicity_budget([2.5, -3.0], 2.0, two_sided=False)
+    assert result.observed == 1
+    assert result.expected == pytest.approx(2 * 0.02275, abs=0.001)
+
+
+def test_multiplicity_budget_negative_threshold_raises() -> None:
+    with pytest.raises(InvalidInputError):
+        multiplicity_budget([1.0], -1.0)

--- a/tests/aldegonde/test_perm.py
+++ b/tests/aldegonde/test_perm.py
@@ -1,0 +1,136 @@
+import random
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from aldegonde import perm
+from aldegonde.exceptions import InvalidInputError
+
+
+def random_perms(max_size: int = 12) -> st.SearchStrategy[list[int]]:
+    return st.integers(min_value=1, max_value=max_size).map(
+        lambda n: random.Random(n).sample(range(n), n)
+    )
+
+
+perms = st.permutations(list(range(6)))
+
+
+def test_identity() -> None:
+    assert perm.identity(4) == [0, 1, 2, 3]
+    assert perm.identity(0) == []
+
+
+@given(perms)
+def test_compose_with_inverse_is_identity(p: list[int]) -> None:
+    assert perm.compose(p, perm.invert(p)) == perm.identity(len(p))
+    assert perm.compose(perm.invert(p), p) == perm.identity(len(p))
+
+
+def test_compose_applies_inner_first() -> None:
+    f = [1, 2, 0]  # 0->1, 1->2, 2->0
+    g = [0, 2, 1]  # swap 1 and 2
+    assert perm.compose(f, g) == [f[g[i]] for i in range(3)]
+
+
+def test_compose_size_mismatch_raises() -> None:
+    with pytest.raises(InvalidInputError):
+        perm.compose([0, 1], [0, 1, 2])
+
+
+@given(perms, st.integers(min_value=-8, max_value=8))
+def test_power_matches_repeated_composition(p: list[int], k: int) -> None:
+    expected = perm.identity(len(p))
+    step = p if k >= 0 else perm.invert(p)
+    for _ in range(abs(k)):
+        expected = perm.compose(step, expected)
+    assert perm.power(p, k) == expected
+
+
+@given(perms)
+def test_power_at_order_is_identity(p: list[int]) -> None:
+    assert perm.power(p, perm.order(p)) == perm.identity(len(p))
+
+
+def test_order_is_lcm_of_cycle_lengths() -> None:
+    p = perm.from_cycles([[0, 1, 2], [3, 4]], 6)
+    assert perm.order(p) == 6
+    assert perm.order(perm.identity(5)) == 1
+
+
+def test_cycles_canonical_form() -> None:
+    p = perm.from_cycles([[2, 0, 1], [4, 3]], 6)
+    assert perm.cycles(p) == [[0, 1, 2], [3, 4], [5]]
+
+
+def test_cycle_type_sorted_descending() -> None:
+    p = perm.from_cycles([[0, 1], [2, 3, 4]], 7)
+    assert perm.cycle_type(p) == (3, 2, 1, 1)
+
+
+def test_parity_of_transposition_is_odd() -> None:
+    assert perm.parity(perm.from_cycles([[0, 1]], 4)) == -1
+    assert perm.parity(perm.identity(4)) == 1
+    # a 3-cycle is even
+    assert perm.parity(perm.from_cycles([[0, 1, 2]], 4)) == 1
+
+
+@given(perms, perms)
+def test_parity_is_multiplicative(p: list[int], q: list[int]) -> None:
+    assert perm.parity(perm.compose(p, q)) == perm.parity(p) * perm.parity(q)
+
+
+def test_from_cycles_rejects_repeated_point() -> None:
+    with pytest.raises(InvalidInputError):
+        perm.from_cycles([[0, 1], [1, 2]], 4)
+
+
+def test_from_cycles_rejects_out_of_range() -> None:
+    with pytest.raises(InvalidInputError):
+        perm.from_cycles([[0, 5]], 4)
+
+
+def test_from_cycle_type_has_requested_type() -> None:
+    p = perm.from_cycle_type([3, 2], 7)
+    assert perm.cycle_type(p) == (3, 2, 1, 1)
+
+
+def test_from_cycle_type_overrun_raises() -> None:
+    with pytest.raises(InvalidInputError):
+        perm.from_cycle_type([3, 3], 5)
+
+
+@given(perms, perms)
+def test_conjugate_preserves_cycle_type(p: list[int], s: list[int]) -> None:
+    assert perm.cycle_type(perm.conjugate(p, s)) == perm.cycle_type(p)
+
+
+@given(perms)
+def test_transposition_conjugate_preserves_cycle_type(p: list[int]) -> None:
+    mutated = perm.transposition_conjugate(p, 0, 3)
+    assert perm.cycle_type(mutated) == perm.cycle_type(p)
+
+
+def test_random_permutation_is_valid_and_seeded() -> None:
+    a = perm.random_permutation(10, random.Random(3))
+    b = perm.random_permutation(10, random.Random(3))
+    perm.validate_permutation(a)
+    assert a == b
+
+
+def test_key_round_trip() -> None:
+    alphabet = "ABCD"
+    key = {"A": "C", "B": "A", "C": "D", "D": "B"}
+    p = perm.from_key(alphabet, key)
+    assert perm.to_key(alphabet, p) == key
+
+
+def test_from_key_rejects_non_bijection() -> None:
+    with pytest.raises(InvalidInputError):
+        perm.from_key("ABC", {"A": "B", "B": "B", "C": "A"})
+
+
+def test_validate_permutation_rejects_duplicates() -> None:
+    with pytest.raises(InvalidInputError):
+        perm.validate_permutation([0, 1, 1])


### PR DESCRIPTION
Surveys the ~120 scripts in `experiments/` for reusable, alphabet-agnostic cryptanalysis primitives and extracts them into the library, one commit per slice.

## Contents

**Survey & plan** (`docs/extraction-candidates.md`): ranked catalog of every extraction candidate with duplication evidence and file:line pointers, the general-vs-3301 placement rule (general engines in `stats`/`analysis`, LP-tuned parameterizations in `c3301`), and a discoverability plan. `experiments/CLAUDE.md` adds a question → API lookup table that agents load automatically, updated in the same commit as each slice.

**Slice 1 — core stats** (one commit):
- `aldegonde.perm`: permutation algebra (compose, invert, power, order, parity, cycles, conjugation, key conversion)
- `stats.nulls`: generative Markov null family (`markov_model`, `fitted_markov`, `doublet_markov`) beside the multiset-exact shuffles; `c3301.low_doublet_markov_null` as the LP-tuned wrapper
- `stats.chisq`: Wilson-Hilferty z, uniformity, weighted goodness-of-fit, exposure-weighted rate uniformity, lag contingency with renormalized off-diagonal masking
- `stats.multitest`: Bonferroni, Šidák, expected-max z, multiplicity budget
- `stats.kappa_spectrum`: all-lags doublet z-spectrum against the frequency-matched null
- `analysis.coincidence`: n-gram boundary coincidence, match-separation histogram, within-word delta histogram, bucket coincidence
- `analysis.relations`: linear/positional relation scans (affine, LFSR, drifting-key detectors)
- `analysis.bounds`: exact min/max doublet rate over all substitutions via assignment

**Slice 2 — solver framework** (one commit): generic hill climber with restarts and multi-start, swap/conjugation neighborhoods, filter-cascade harness, autokey digraph-class constraints.

**Slice 3 — keystream & simulation kits** (one commit): integer-sequence keystream catalog, running-key offset scans with empirical nulls, autokey depth-split detector, Markov plaintext generator, statistical fingerprint battery.

**Slice 4 — higher-order detectors** (one commit): FFT cross-correlation depth scan, multiplier-DFT periodicity scan, 4-point statistic family, binomial helpers (Wilson interval, two-proportion z).

All primitives work over arbitrary alphabets. Every slice ships with tests; remaining mypy/ruff findings in the repo pre-date this branch. Migration of the experiment scripts onto the new APIs is deliberately deferred — they are records of past runs, best migrated file-by-file as they are next touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDKfTjc4VZxrdzxBPMxige

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDKfTjc4VZxrdzxBPMxige)_